### PR TITLE
Add directives for adoption within RFML

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,12 @@
+import com.scalapenos.sbt.prompt.SbtPrompt.autoImport._
+
+promptTheme := com.scalapenos.sbt.prompt.PromptThemes.ScalapenosTheme
+
 val mamlVersion = "0.0.2" + scala.util.Properties.envOrElse("MAML_VERSION_SUFFIX", "")
 
 /** Project configurations */
 lazy val root = project.in(file("."))
-  .aggregate(mamlJS, mamlJVM, mamlSpark)
+  .aggregate(mamlJs, mamlJvm, mamlSpark)
   .settings(commonSettings:_*)
   .settings(
     licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
@@ -42,10 +46,10 @@ lazy val maml = crossProject.in(file("."))
     name := "maml-js"
   ).jsSettings(commonSettings:_*)
 
-lazy val mamlJVM = maml.jvm
-lazy val mamlJS = maml.js
+lazy val mamlJvm = maml.jvm
+lazy val mamlJs = maml.js
 lazy val mamlSpark = project.in(file("spark"))
-  .dependsOn(mamlJVM)
+  .dependsOn(mamlJvm)
   .settings(publishSettings:_*)
   .settings(commonSettings:_*)
 

--- a/jvm/src/main/scala/ast/TileLiteral.scala
+++ b/jvm/src/main/scala/ast/TileLiteral.scala
@@ -2,11 +2,11 @@ package com.azavea.maml.ast
 
 import com.azavea.maml.eval.tile._
 
-import geotrellis.raster.Tile
+import geotrellis.raster._
 
 import java.util.UUID
 
-case class TileLiteral(tile: Tile) extends Source {
+case class TileLiteral(tile: Tile, extent: RasterExtent) extends Source {
   val kind = MamlKind.Tile
 }
 

--- a/jvm/src/main/scala/dsl/tile/LazyTileMethods.scala
+++ b/jvm/src/main/scala/dsl/tile/LazyTileMethods.scala
@@ -1,0 +1,223 @@
+package com.azavea.maml.dsl.tile
+
+import com.azavea.maml.eval.tile._
+
+import geotrellis.raster._
+import geotrellis.raster.mapalgebra.local._
+
+
+trait LazyTileOperations {
+  val self: LazyTile
+
+  /** Simple local operations */
+  def +(other: LazyTile): LazyTile = LazyTile.DualCombine(List(self, other), Add.combine, Add.combine)
+  def +(other: Int): LazyTile = LazyTile.DualMap(List(self), { Add.combine(_, other) }, { Add.combine(_, other) })
+  def +:(other: Int): LazyTile = LazyTile.DualMap(List(self), { Add.combine(_, other) }, { Add.combine(_, other) })
+  def +(other: Double): LazyTile = LazyTile.DualMap(List(self), { Add.combine(_, d2i(other)) }, { Add.combine(_, other) })
+  def +:(other: Double): LazyTile = LazyTile.DualMap(List(self), { Add.combine(_, d2i(other)) }, { Add.combine(_, other) })
+
+  def -(other: LazyTile): LazyTile = LazyTile.DualCombine(List(self, other), Subtract.combine, Subtract.combine)
+  def -(other: Int): LazyTile = LazyTile.DualMap(List(self), { Subtract.combine(_, other) }, { Subtract.combine(_, i2d(other)) })
+  def -:(other: Int): LazyTile = LazyTile.DualMap(List(self), { Subtract.combine(_, other) }, { Subtract.combine(_, i2d(other)) })
+  def -(other: Double): LazyTile = LazyTile.DualMap(List(self), { Subtract.combine(_, d2i(other)) }, { Subtract.combine(_, other) })
+  def -:(other: Double): LazyTile = LazyTile.DualMap(List(self), { Subtract.combine(_, d2i(other)) }, { Subtract.combine(_, other) })
+
+  def *(other: LazyTile): LazyTile = LazyTile.DualCombine(List(self, other), Multiply.combine, Multiply.combine)
+  def *(other: Int): LazyTile = LazyTile.DualMap(List(self), { Multiply.combine(_, other) }, { Multiply.combine(_, i2d(other)) })
+  def *:(other: Int): LazyTile = LazyTile.DualMap(List(self), { Multiply.combine(_, other) }, { Multiply.combine(_, i2d(other)) })
+  def *(other: Double): LazyTile = LazyTile.DualMap(List(self), { Multiply.combine(_, d2i(other)) }, { Multiply.combine(_, other) })
+  def *:(other: Double): LazyTile = LazyTile.DualMap(List(self), { Multiply.combine(_, d2i(other)) }, { Multiply.combine(_, other) })
+
+  def /(other: LazyTile): LazyTile = LazyTile.DualCombine(List(self, other), Divide.combine, Divide.combine)
+  def /(other: Int): LazyTile = LazyTile.DualMap(List(self), { Divide.combine(_, other) }, { Divide.combine(_, i2d(other)) })
+  def /:(other: Int): LazyTile = LazyTile.DualMap(List(self), { Divide.combine(_, other) }, { Divide.combine(_, i2d(other)) })
+  def /(other: Double): LazyTile = LazyTile.DualMap(List(self), { Divide.combine(_, d2i(other)) }, { Divide.combine(_, other) })
+  def /:(other: Double): LazyTile = LazyTile.DualMap(List(self), { Divide.combine(_, d2i(other)) }, { Divide.combine(_, other) })
+
+  /** Comparisons */
+  def <(other: LazyTile): LazyTile =
+    LazyTile.DualCombine(List(self, other),
+      {(i1: Int, i2: Int) => if (Less.compare(i1, i2)) 1 else 0 },
+      {(d1: Double, d2: Double) => if (Less.compare(d1, d2)) 1.0 else 0.0 }
+    )
+  def <(other: Int): LazyTile =
+    LazyTile.DualMap(List(self),
+      {(i: Int) => if (Less.compare(i, other.toInt)) 1 else 0},
+      {(d: Double) => if (Less.compare(d, other)) 1.0 else 0.0 }
+    )
+  def <(other: Double): LazyTile =
+    LazyTile.DualMap(List(self),
+      {(i: Int) => if (Less.compare(i, other.toInt)) 1 else 0},
+      {(d: Double) => if (Less.compare(d, other)) 1.0 else 0.0 }
+    )
+
+  def <=(other: LazyTile): LazyTile =
+    LazyTile.DualCombine(List(self, other),
+      {(i1: Int, i2: Int) => if (LessOrEqual.compare(i1, i2)) 1 else 0 },
+      {(d1: Double, d2: Double) => if (LessOrEqual.compare(d1, d2)) 1.0 else 0.0 }
+    )
+  def <=(other: Int): LazyTile =
+    LazyTile.DualMap(List(self),
+      {(i: Int) => if (LessOrEqual.compare(i, other.toInt)) 1 else 0},
+      {(d: Double) => if (LessOrEqual.compare(d, other)) 1.0 else 0.0 }
+    )
+  def <=(other: Double): LazyTile =
+    LazyTile.DualMap(List(self),
+      {(i: Int) => if (LessOrEqual.compare(i, other.toInt)) 1 else 0},
+      {(d: Double) => if (LessOrEqual.compare(d, other)) 1.0 else 0.0 }
+    )
+
+  def ===(other: LazyTile): LazyTile =
+    LazyTile.DualCombine(List(self, other),
+      {(i1: Int, i2: Int) => if (Equal.compare(i1, i2)) 1 else 0 },
+      {(d1: Double, d2: Double) => if (Equal.compare(d1, d2)) 1.0 else 0.0 }
+    )
+  def ===(other: Int): LazyTile =
+    LazyTile.DualMap(List(self),
+      {(i: Int) => if (Equal.compare(i, other.toInt)) 1 else 0},
+      {(d: Double) => if (Equal.compare(d, other)) 1.0 else 0.0 }
+    )
+  def ===(other: Double): LazyTile =
+    LazyTile.DualMap(List(self),
+      {(i: Int) => if (Equal.compare(i, other.toInt)) 1 else 0},
+      {(d: Double) => if (Equal.compare(d, other)) 1.0 else 0.0 }
+    )
+
+  def !==(other: LazyTile): LazyTile =
+    LazyTile.DualCombine(List(self, other),
+      {(i1: Int, i2: Int) => if (Unequal.compare(i1, i2)) 1 else 0 },
+      {(d1: Double, d2: Double) => if (Unequal.compare(d1, d2)) 1.0 else 0.0 }
+    )
+  def !==(other: Int): LazyTile =
+    LazyTile.DualMap(List(self),
+      {(i: Int) => if (Unequal.compare(i, other.toInt)) 1 else 0},
+      {(d: Double) => if (Unequal.compare(d, other)) 1.0 else 0.0 }
+    )
+  def !==(other: Double): LazyTile =
+    LazyTile.DualMap(List(self),
+      {(i: Int) => if (Unequal.compare(i, other.toInt)) 1 else 0},
+      {(d: Double) => if (Unequal.compare(d, other)) 1.0 else 0.0 }
+    )
+
+  def >=(other: LazyTile): LazyTile =
+    LazyTile.DualCombine(List(self, other),
+      {(i1: Int, i2: Int) => if (GreaterOrEqual.compare(i1, i2)) 1 else 0 },
+      {(d1: Double, d2: Double) => if (GreaterOrEqual.compare(d1, d2)) 1.0 else 0.0 }
+    )
+  def >=(other: Int): LazyTile =
+    LazyTile.DualMap(List(self),
+      {(i: Int) => if (GreaterOrEqual.compare(i, other.toInt)) 1 else 0},
+      {(d: Double) => if (GreaterOrEqual.compare(d, other)) 1.0 else 0.0 }
+    )
+  def >=(other: Double): LazyTile =
+    LazyTile.DualMap(List(self),
+      {(i: Int) => if (GreaterOrEqual.compare(i, other.toInt)) 1 else 0},
+      {(d: Double) => if (GreaterOrEqual.compare(d, other)) 1.0 else 0.0 }
+    )
+
+  def >(other: LazyTile): LazyTile =
+    LazyTile.DualCombine(List(self, other),
+      {(i1: Int, i2: Int) => if (Greater.compare(i1, i2)) 1 else 0 },
+      {(d1: Double, d2: Double) => if (Greater.compare(d1, d2)) 1.0 else 0.0 }
+    )
+  def >(other: Int): LazyTile =
+    LazyTile.DualMap(List(self),
+      {(i: Int) => if (Greater.compare(i, other.toInt)) 1 else 0},
+      {(d: Double) => if (Greater.compare(d, other)) 1.0 else 0.0 }
+    )
+  def >(other: Double): LazyTile =
+    LazyTile.DualMap(List(self),
+      {(i: Int) => if (Greater.compare(i, other.toInt)) 1 else 0},
+      {(d: Double) => if (Greater.compare(d, other)) 1.0 else 0.0 }
+    )
+
+  /** Trigonometric Operations */
+  def sin: LazyTile = LazyTile.DualMap(List(self),
+    { z: Int => if(isNoData(z)) z else d2i(math.sin(z)) },
+    { z => if(isNoData(z)) z else math.sin(z) }
+  )
+  def cos: LazyTile = LazyTile.DualMap(List(self),
+    { z: Int => if(isNoData(z)) z else d2i(math.cos(z)) },
+    { z => if(isNoData(z)) z else math.cos(z) }
+  )
+  def tan: LazyTile = LazyTile.DualMap(List(self),
+    { z: Int => if(isNoData(z)) z else d2i(math.tan(z)) },
+    { z => if(isNoData(z)) z else math.tan(z) }
+  )
+
+  def sinh: LazyTile = LazyTile.DualMap(List(self),
+    { z: Int => if(isNoData(z)) z else d2i(math.sinh(z)) },
+    { z => if(isNoData(z)) z else math.sinh(z) }
+  )
+  def cosh: LazyTile = LazyTile.DualMap(List(self),
+    { z: Int => if(isNoData(z)) z else d2i(math.cosh(z)) },
+    { z => if(isNoData(z)) z else math.cosh(z) }
+  )
+  def tanh: LazyTile = LazyTile.DualMap(List(self),
+    { z: Int => if(isNoData(z)) z else d2i(math.tanh(z)) },
+    { z => if(isNoData(z)) z else math.tanh(z) }
+  )
+
+  def asin: LazyTile = LazyTile.DualMap(List(self),
+    { z: Int => if(isNoData(z)) z else d2i(math.asin(z)) },
+    { z => if(isNoData(z)) z else math.asin(z) }
+  )
+  def acos: LazyTile = LazyTile.DualMap(List(self),
+    { z: Int => if(isNoData(z)) z else d2i(math.acos(z)) },
+    { z => if(isNoData(z)) z else math.acos(z) }
+  )
+  def atan: LazyTile = LazyTile.DualMap(List(self),
+    { z: Int => if(isNoData(z)) z else d2i(math.atan(z)) },
+    { z => if(isNoData(z)) z else math.atan(z) }
+  )
+
+  /** Rounding Operations */
+  def round: LazyTile = LazyTile.DualMap(List(self), identity, { z => if(isNoData(z)) z else math.round(z) })
+
+  def floor: LazyTile = LazyTile.DualMap(List(self), identity, { z => if(isNoData(z)) z else math.floor(z) })
+
+  def ceil: LazyTile = LazyTile.DualMap(List(self), identity, { z => if(isNoData(z)) z else math.ceil(z) })
+
+  /** Rarer Arithmetic Operations */
+  def logE: LazyTile = LazyTile.DualMap(List(self),
+    { z: Int => if(isNoData(z)) z else d2i(math.log(i2d(z))) },
+    { z => if(isNoData(z)) z else math.log(z) }
+  )
+
+  def log10: LazyTile = LazyTile.DualMap(List(self),
+    { z: Int => if(isNoData(z)) z else d2i(math.log10(i2d(z))) },
+    { z => if(isNoData(z)) z else math.log10(z) }
+  )
+
+  def sqrt: LazyTile = LazyTile.DualMap(List(self),
+    { z: Int => if(isNoData(z)) z else d2i(math.sqrt(i2d(z))) },
+    { z => if(isNoData(z)) z else math.sqrt(z) }
+  )
+
+  def abs: LazyTile = LazyTile.DualMap(List(self),
+    { z: Int => if(isNoData(z)) z else math.abs(z) },
+    { z => if(isNoData(z)) z else math.abs(z) }
+  )
+
+  def isDefined: LazyTile = LazyTile.DualMap(List(self),
+    { z: Int => if (isData(z)) 1 else 0 },
+    { z => if (isData(z)) 1.0 else 0.0 }
+  )
+
+  def isUndefined: LazyTile = LazyTile.DualMap(List(self),
+    { z: Int => if (isNoData(z)) 1 else 0 },
+    { z => if (isNoData(z)) 1.0 else 0.0 }
+  )
+
+  def pow(i: Int): LazyTile = LazyTile.DualMap(List(self),
+    { z: Int => if (isNoData(z)) 1 else 0 },
+    { z => if (isNoData(z)) 1.0 else 0.0 }
+  )
+
+  def pow(d: Double): LazyTile = LazyTile.DualMap(List(self),
+    { z: Int => if (isNoData(z)) 1 else 0 },
+    { z => if (isNoData(z)) 1.0 else 0.0 }
+  )
+}
+
+

--- a/jvm/src/main/scala/dsl/tile/package.scala
+++ b/jvm/src/main/scala/dsl/tile/package.scala
@@ -1,0 +1,8 @@
+package com.azavea.maml.dsl
+
+import com.azavea.maml.eval.tile._
+
+
+package object tile {
+  implicit class LazyTileExtensions(val self: LazyTile) extends LazyTileOperations
+}

--- a/jvm/src/main/scala/eval/BufferingInterpreter.scala
+++ b/jvm/src/main/scala/eval/BufferingInterpreter.scala
@@ -3,12 +3,14 @@ package com.azavea.maml.eval
 import com.azavea.maml.ast._
 import com.azavea.maml.util._
 import com.azavea.maml.eval.directive._
+import com.azavea.maml.eval.tile._
 
 import cats._
 import cats.implicits._
 import cats.data.Validated._
 import cats.data.{NonEmptyList => NEL, _}
 import geotrellis.raster.GridBounds
+import geotrellis.raster.mapalgebra.focal
 
 import scala.reflect.ClassTag
 
@@ -17,6 +19,12 @@ case class BufferingInterpreter(
   directives: List[ScopedDirective[BufferingInterpreter.Scope]],
   options: BufferingInterpreter.Options = BufferingInterpreter.Options(256)
 ) extends ScopedInterpreter[BufferingInterpreter.Scope] {
+
+  def prependDirective(directive: ScopedDirective[BufferingInterpreter.Scope]): ScopedInterpreter[BufferingInterpreter.Scope] =
+    BufferingInterpreter(directive +: directives, options)
+
+  def appendDirective(directive: ScopedDirective[BufferingInterpreter.Scope]): ScopedInterpreter[BufferingInterpreter.Scope] =
+    BufferingInterpreter(directives :+ directive, options)
 
   def scopeFor(exp: Expression, previous: Option[BufferingInterpreter.Scope]): BufferingInterpreter.Scope = {
     val scope = previous.getOrElse(BufferingInterpreter.Scope(0, options.tileSize))
@@ -37,9 +45,138 @@ case class BufferingInterpreter(
 
 
 object BufferingInterpreter {
-  case class Options(tileSize: Int)
   case class Scope(buffer: Int, tileSize: Int)
+  case class Options(tileSize: Int)
 
-  def gridbounds(expectedTileSize: Int, buffer: Int, extent: Int): GridBounds =
-    GridBounds(extent, extent, expectedTileSize - 1 + buffer * 2 + extent, expectedTileSize - 1 + buffer * 2 + extent)
+  def DEFAULT = BufferingInterpreter(
+    List(
+      ScopedDirective.pure[TileLiteral](SourceDirectives.tileLiteral),
+      ScopedDirective.pure[IntLiteral](SourceDirectives.intLiteral),
+      ScopedDirective.pure[DoubleLiteral](SourceDirectives.dblLiteral),
+      ScopedDirective.pure[BoolLiteral](SourceDirectives.boolLiteral),
+      ScopedDirective.pure[GeomJson](SourceDirectives.geomJson),
+      ScopedDirective.pure[Addition](OpDirectives.additionTile orElse OpDirectives.additionInt orElse OpDirectives.additionDouble),
+      ScopedDirective.pure[Subtraction](OpDirectives.subtraction),
+      ScopedDirective.pure[Multiplication](OpDirectives.multiplicationTile orElse OpDirectives.multiplicationInt orElse OpDirectives.multiplicationDouble),
+      ScopedDirective.pure[Division](OpDirectives.division),
+      ScopedDirective.pure[Max](OpDirectives.maxTile orElse OpDirectives.maxInt orElse OpDirectives.maxDouble),
+      ScopedDirective.pure[Min](OpDirectives.minTile orElse OpDirectives.minInt orElse OpDirectives.minDouble),
+      ScopedDirective.pure[Less](OpDirectives.lessThan),
+      ScopedDirective.pure[LessOrEqual](OpDirectives.lessThanOrEqualTo),
+      ScopedDirective.pure[Equal](OpDirectives.equalTo),
+      ScopedDirective.pure[Unequal](OpDirectives.notEqualTo),
+      ScopedDirective.pure[Greater](OpDirectives.greaterThan),
+      ScopedDirective.pure[GreaterOrEqual](OpDirectives.greaterThanOrEqualTo),
+      ScopedDirective.pure[And](OpDirectives.and),
+      ScopedDirective.pure[Or](OpDirectives.or),
+      ScopedDirective.pure[Xor](OpDirectives.xor),
+      ScopedDirective.pure[Masking](OpDirectives.masking),
+      ScopedDirective.pure[Atan2](OpDirectives.atan2),
+      ScopedDirective.pure[Sin](UnaryDirectives.sin),
+      ScopedDirective.pure[Cos](UnaryDirectives.cos),
+      ScopedDirective.pure[Tan](UnaryDirectives.tan),
+      ScopedDirective.pure[Sinh](UnaryDirectives.sinh),
+      ScopedDirective.pure[Cosh](UnaryDirectives.cosh),
+      ScopedDirective.pure[Tanh](UnaryDirectives.tanh),
+      ScopedDirective.pure[Asin](UnaryDirectives.asin),
+      ScopedDirective.pure[Acos](UnaryDirectives.acos),
+      ScopedDirective.pure[Atan](UnaryDirectives.atan),
+      ScopedDirective.pure[Round](UnaryDirectives.round),
+      ScopedDirective.pure[Floor](UnaryDirectives.floor),
+      ScopedDirective.pure[Ceil](UnaryDirectives.ceil),
+      ScopedDirective.pure[LogE](UnaryDirectives.naturalLog),
+      ScopedDirective.pure[Log10](UnaryDirectives.log10),
+      ScopedDirective.pure[SquareRoot](UnaryDirectives.sqrt),
+      ScopedDirective.pure[Abs](UnaryDirectives.abs),
+      ScopedDirective.pure[Undefined](UnaryDirectives.isUndefined),
+      ScopedDirective.pure[Defined](UnaryDirectives.isDefined),
+      ScopedDirective.pure[NumericNegation](UnaryDirectives.numericNegation),
+      ScopedDirective.pure[LogicalNegation](UnaryDirectives.logicalNegation),
+      ScopedDirective.pure[Classification](UnaryDirectives.classification),
+      focalMax,
+      focalMin,
+      focalMean,
+      focalMode,
+      focalMedian,
+      focalSum,
+      focalStandardDeviation
+    ), Options(256)
+  )
+
+  val focalMax = ScopedDirective[Scope] { case (fm@FocalMax(_, neighborhood), childResults, scope) =>
+    val n = NeighborhoodConversion(neighborhood)
+    val gridbounds =
+      GridBounds(n.extent, n.extent, scope.tileSize - 1 + scope.buffer * 2 + n.extent, scope.tileSize - 1 + scope.buffer * 2 + n.extent)
+
+    childResults.head match {
+      case TileResult(lzTile) =>
+        Valid(TileResult(LazyTile.Focal(List(lzTile), n, Some(gridbounds), focal.Max.apply _)))
+    }
+  }
+
+  val focalMin = ScopedDirective[Scope] { case (fm@FocalMin(_, neighborhood), childResults, scope) =>
+    val n = NeighborhoodConversion(neighborhood)
+    val gridbounds =
+      GridBounds(n.extent, n.extent, scope.tileSize - 1 + scope.buffer * 2 + n.extent, scope.tileSize - 1 + scope.buffer * 2 + n.extent)
+
+    childResults.head match {
+      case TileResult(lzTile) =>
+        Valid(TileResult(LazyTile.Focal(List(lzTile), n, Some(gridbounds), focal.Min.apply _)))
+    }
+  }
+
+  val focalMean = ScopedDirective[Scope] { case (fm@FocalMean(_, neighborhood), childResults, scope) =>
+    val n = NeighborhoodConversion(neighborhood)
+    val gridbounds =
+      GridBounds(n.extent, n.extent, scope.tileSize - 1 + scope.buffer * 2 + n.extent, scope.tileSize - 1 + scope.buffer * 2 + n.extent)
+
+    childResults.head match {
+      case TileResult(lzTile) =>
+        Valid(TileResult(LazyTile.Focal(List(lzTile), n, Some(gridbounds), focal.Mean.apply _)))
+    }
+  }
+
+  val focalMedian = ScopedDirective[Scope] { case (fm@FocalMedian(_, neighborhood), childResults, scope) =>
+    val n = NeighborhoodConversion(neighborhood)
+    val gridbounds =
+      GridBounds(n.extent, n.extent, scope.tileSize - 1 + scope.buffer * 2 + n.extent, scope.tileSize - 1 + scope.buffer * 2 + n.extent)
+
+    childResults.head match {
+      case TileResult(lzTile) =>
+        Valid(TileResult(LazyTile.Focal(List(lzTile), n, Some(gridbounds), focal.Median.apply _)))
+    }
+  }
+
+  val focalMode = ScopedDirective[Scope] { case (fm@FocalMode(_, neighborhood), childResults, scope) =>
+    val n = NeighborhoodConversion(neighborhood)
+    val gridbounds =
+      GridBounds(n.extent, n.extent, scope.tileSize - 1 + scope.buffer * 2 + n.extent, scope.tileSize - 1 + scope.buffer * 2 + n.extent)
+
+    childResults.head match {
+      case TileResult(lzTile) =>
+        Valid(TileResult(LazyTile.Focal(List(lzTile), n, Some(gridbounds), focal.Mode.apply _)))
+    }
+  }
+
+  val focalSum = ScopedDirective[Scope] { case (fm@FocalSum(_, neighborhood), childResults, scope) =>
+    val n = NeighborhoodConversion(neighborhood)
+    val gridbounds =
+      GridBounds(n.extent, n.extent, scope.tileSize - 1 + scope.buffer * 2 + n.extent, scope.tileSize - 1 + scope.buffer * 2 + n.extent)
+
+    childResults.head match {
+      case TileResult(lzTile) =>
+        Valid(TileResult(LazyTile.Focal(List(lzTile), n, Some(gridbounds), focal.Sum.apply _)))
+    }
+  }
+
+  val focalStandardDeviation = ScopedDirective[Scope] { case (fm@FocalStdDev(_, neighborhood), childResults, scope) =>
+    val n = NeighborhoodConversion(neighborhood)
+    val gridbounds =
+      GridBounds(n.extent, n.extent, scope.tileSize - 1 + scope.buffer * 2 + n.extent, scope.tileSize - 1 + scope.buffer * 2 + n.extent)
+
+    childResults.head match {
+      case TileResult(lzTile) =>
+        Valid(TileResult(LazyTile.Focal(List(lzTile), n, Some(gridbounds), focal.StandardDeviation.apply _)))
+    }
+  }
 }

--- a/jvm/src/main/scala/eval/Interpreter.scala
+++ b/jvm/src/main/scala/eval/Interpreter.scala
@@ -13,15 +13,11 @@ import scala.reflect.ClassTag
 trait Interpreter {
   def fallbackDirective: Directive
   def instructions(expression: Expression, children: List[Result]): Interpreted[Result]
+  def appendDirective(directive: Directive): Interpreter
+  def prependDirective(directive: Directive): Interpreter
   def apply(exp: Expression): Interpreted[Result] = {
     val children: Interpreted[List[Result]] = exp.children.map(apply).sequence
     children.andThen({ childRes => instructions(exp, childRes) })
   }
-}
-
-object Interpreter {
-  def naive(directives: Directive*) = NaiveInterpreter(directives.toList)
-
-  def buffering(directives: ScopedDirective[BufferingInterpreter.Scope]*) = BufferingInterpreter(directives.toList)
 }
 

--- a/jvm/src/main/scala/eval/InterpreterError.scala
+++ b/jvm/src/main/scala/eval/InterpreterError.scala
@@ -30,8 +30,12 @@ case class UnhandledCase(exp: Expression, kind: MamlKind) extends InterpreterErr
   def repr = s"A branch of Interpreter logic has yet to be implemented for the expression ${exp} and the kind $kind"
 }
 
-case class ASTDecodeError(json: Json, msg: DecodingFailure) extends InterpreterError {
-  def repr = s"Unable to decode the json ${json} as AST: ${msg}"
+case class ASTParseError(json: String, reason: String) extends InterpreterError {
+  def repr = s"Unable to parse ${json} as JSON: ${reason}"
+}
+
+case class ASTDecodeError(json: Json, reason: String) extends InterpreterError {
+  def repr = s"Unable to decode the json ${json} as AST: ${reason}"
 }
 
 case class EvalTypeError(found: String, expected: List[String]) extends InterpreterError {

--- a/jvm/src/main/scala/eval/InterpreterException.scala
+++ b/jvm/src/main/scala/eval/InterpreterException.scala
@@ -1,0 +1,7 @@
+package com.azavea.maml.eval
+
+import cats.data.NonEmptyList
+
+
+case class InterpreterException(errors: NonEmptyList[InterpreterError]) extends Exception
+

--- a/jvm/src/main/scala/eval/NaiveInterpreter.scala
+++ b/jvm/src/main/scala/eval/NaiveInterpreter.scala
@@ -11,6 +11,13 @@ import scala.reflect.ClassTag
 
 
 case class NaiveInterpreter(directives: List[Directive]) extends Interpreter {
+
+  def prependDirective(directive: Directive): Interpreter =
+    NaiveInterpreter(directive +: directives)
+
+  def appendDirective(directive: Directive): Interpreter =
+    NaiveInterpreter(directives :+ directive)
+
   val fallbackDirective: Directive =
     { case (exp, res) => Invalid(NEL.of(UnhandledCase(exp, exp.kind))) }
 

--- a/jvm/src/main/scala/eval/Resolver.scala
+++ b/jvm/src/main/scala/eval/Resolver.scala
@@ -2,12 +2,14 @@ package com.azavea.maml.eval
 
 import com.azavea.maml.ast._
 import com.azavea.maml.eval._
+import com.azavea.maml.eval.tile.TileLayouts
 
 import geotrellis.raster._
 import geotrellis.raster.render._
 import geotrellis.spark._
 import geotrellis.spark.io._
 import geotrellis.spark.io.s3._
+import geotrellis.spark.tiling._
 
 import cats.data.{NonEmptyList => NEL}
 import cats.data.Validated._
@@ -19,13 +21,14 @@ import scala.util.{Try, Success, Failure}
 class Resolver(ec: ExecutionContext) {
   implicit val execution = ec
   def tmsLiteral(exp: Expression): (Int, Int, Int) => Future[Interpreted[Expression]] = (z: Int, x: Int, y: Int) => {
+    lazy val extent = TileLayouts(z).mapTransform(SpatialKey(x,y))
     exp match {
       case ValueReaderTileSource(bucket, root, layerId) => Future {
         val reader = S3ValueReader(bucket, root).reader[SpatialKey, Tile](LayerId(layerId, z))
         Try {
           reader.read(x, y)
         } match {
-          case Success(tile) => Valid(TileLiteral(tile))
+          case Success(tile) => Valid(TileLiteral(tile, RasterExtent(tile, extent)))
           case Failure(e: ValueNotFoundError) => Invalid(NEL.of(S3TileResolutionError(exp, Some((z, x, y)))))
           case Failure(e) =>  Invalid(NEL.of(UnknownTileResolutionError(exp, Some((z, x, y)))))
         }

--- a/jvm/src/main/scala/eval/ScopedInterpreter.scala
+++ b/jvm/src/main/scala/eval/ScopedInterpreter.scala
@@ -11,6 +11,8 @@ import geotrellis.raster.GridBounds
 
 trait ScopedInterpreter[Scope] {
   def scopeFor(exp: Expression, previous: Option[Scope]): Scope
+  def appendDirective(directive: ScopedDirective[Scope]): ScopedInterpreter[Scope]
+  def prependDirective(directive: ScopedDirective[Scope]): ScopedInterpreter[Scope]
   def fallbackDirective: ScopedDirective[Scope]
   def instructions(expression: Expression, children: Seq[Result], scope: Scope): Interpreted[Result]
 

--- a/jvm/src/main/scala/eval/directive/OpDirectives.scala
+++ b/jvm/src/main/scala/eval/directive/OpDirectives.scala
@@ -3,6 +3,7 @@ package com.azavea.maml.eval.directive
 import com.azavea.maml.eval._
 import com.azavea.maml.eval.tile._
 import com.azavea.maml.ast._
+import com.azavea.maml.dsl.tile._
 
 import geotrellis.raster.Tile
 import cats._
@@ -10,8 +11,84 @@ import cats.implicits._
 import cats.data.{NonEmptyList => NEL, _}
 import Validated._
 
+import scala.util.Try
+
 
 object OpDirectives {
+  private def doubleResults(grouped: Map[MamlKind, Seq[Result]]): Interpreted[List[Double]] =
+    grouped.getOrElse(MamlKind.Double, List.empty).map(_.as[Double]).toList.sequence
+
+  private def intResults(grouped: Map[MamlKind, Seq[Result]]): Interpreted[List[Int]] =
+    grouped.getOrElse(MamlKind.Int, List.empty).map(_.as[Int]).toList.sequence
+
+  private def lazytileResults(grouped: Map[MamlKind, Seq[Result]]): Interpreted[List[LazyTile]] =
+    grouped(MamlKind.Tile).map(_.as[LazyTile]).toList.sequence
+
+   private def tileReduction(
+     ti: (LazyTile, Int) => LazyTile,
+     it: (Int, LazyTile) => LazyTile,
+     td: (LazyTile, Double) => LazyTile,
+     dt: (Double, LazyTile) => LazyTile,
+     tt: (LazyTile, LazyTile) => LazyTile,
+     res1: Result,
+     res2: Result
+   ): Result = (res1, res2) match {
+     case (TileResult(lt1), TileResult(lt2)) => TileResult(tt(lt1, lt2))
+     case (TileResult(lt), IntResult(int)) => TileResult((ti(lt, int)))
+     case (IntResult(int), TileResult(lt)) => TileResult((it(int, lt)))
+     case (TileResult(lt), DoubleResult(double)) => TileResult(td(lt, double))
+     case (DoubleResult(double), TileResult(lt)) => TileResult(dt(double, lt))
+   }
+
+   private def tileOrBoolReduction(
+     ti: (LazyTile, Int) => LazyTile,
+     it: (Int, LazyTile) => LazyTile,
+     td: (LazyTile, Double) => LazyTile,
+     dt: (Double, LazyTile) => LazyTile,
+     tt: (LazyTile, LazyTile) => LazyTile,
+     ii: (Int, Int) => Boolean,
+     di: (Double, Int) => Boolean,
+     dd: (Double, Double) => Boolean,
+     id: (Int, Double) => Boolean,
+     res1: Result,
+     res2: Result
+   ): Result = (res1, res2) match {
+     case (TileResult(lt1), TileResult(lt2)) => TileResult(tt(lt1, lt2))
+     case (TileResult(lt), IntResult(int)) => TileResult((ti(lt, int)))
+     case (IntResult(int), TileResult(lt)) => TileResult((it(int, lt)))
+     case (TileResult(lt), DoubleResult(double)) => TileResult(td(lt, double))
+     case (DoubleResult(double), TileResult(lt)) => TileResult(dt(double, lt))
+     case (IntResult(int1), IntResult(int2)) => BoolResult(ii(int1, int2))
+     case (DoubleResult(dbl), IntResult(int)) => BoolResult(di(dbl, int))
+     case (DoubleResult(dbl1), DoubleResult(dbl2)) => BoolResult(dd(dbl1, dbl2))
+     case (IntResult(int), DoubleResult(dbl)) => BoolResult(id(int, dbl))
+   }
+
+   private def tileOrScalarReduction(
+     ti: (LazyTile, Int) => LazyTile,
+     it: (Int, LazyTile) => LazyTile,
+     td: (LazyTile, Double) => LazyTile,
+     dt: (Double, LazyTile) => LazyTile,
+     tt: (LazyTile, LazyTile) => LazyTile,
+     ii: (Int, Int) => Int,
+     di: (Double, Int) => Double,
+     dd: (Double, Double) => Double,
+     id: (Int, Double) => Double,
+     res1: Result,
+     res2: Result
+   ): Result = (res1, res2) match {
+     case (TileResult(lt1), TileResult(lt2)) => TileResult(tt(lt1, lt2))
+     case (TileResult(lt), IntResult(int)) => TileResult((ti(lt, int)))
+     case (IntResult(int), TileResult(lt)) => TileResult((it(int, lt)))
+     case (TileResult(lt), DoubleResult(double)) => TileResult(td(lt, double))
+     case (DoubleResult(double), TileResult(lt)) => TileResult(dt(double, lt))
+     case (IntResult(int1), IntResult(int2)) => IntResult(ii(int1, int2))
+     case (DoubleResult(dbl), IntResult(int)) => DoubleResult(di(dbl, int))
+     case (DoubleResult(dbl1), DoubleResult(dbl2)) => DoubleResult(dd(dbl1, dbl2))
+     case (IntResult(int), DoubleResult(dbl)) => DoubleResult(id(int, dbl))
+   }
+
+  /** Arithmetic Operations */
   val additionDouble = Directive { case (a@Addition(_), childResults) if (a.kind == MamlKind.Double) =>
     childResults
       .map({ _.as[Double] })
@@ -27,58 +104,27 @@ object OpDirectives {
   }
 
   val additionTile = Directive { case (a@Addition(_), childResults) if (a.kind == MamlKind.Tile) =>
-    val grouped = childResults
-      .groupBy(_.kind)
-    val dblRes: Interpreted[List[Double]] =
-      grouped.getOrElse(MamlKind.Double, List.empty)
-        .map({ _.as[Double] })
-        .toList.sequence
-    val intRes: Interpreted[List[Int]] =
-      grouped.getOrElse(MamlKind.Int, List.empty)
-        .map({ _.as[Int] })
-        .toList.sequence
-    val tileRes: Interpreted[List[LazyTile]] =
-      grouped(MamlKind.Tile)
-        .map({ _.as[LazyTile] })
-        .toList.sequence
+    val grouped = childResults.groupBy(_.kind)
 
-    (dblRes |@| intRes |@| tileRes).map({ case (dbls, ints, tiles) =>
+    val scalarSums =
+      (doubleResults(grouped) |@| intResults(grouped)).map { case (dbls, ints) => dbls.sum + ints.sum }
+
+    (lazytileResults(grouped) |@| scalarSums).map { case (tiles, sums) =>
       val tileSum = tiles.reduce({ (lt1: LazyTile, lt2: LazyTile) => LazyTile.DualCombine(List(lt1, lt2), {_ + _}, {_ + _}) })
-      val scalarSum: Double = dbls.sum + ints.sum
-      TileResult(LazyTile.DualMap(List(tileSum), { i: Int => i + scalarSum.toInt }, { i: Double => i + scalarSum }))
-    })
+      TileResult(LazyTile.DualMap(List(tileSum), { i: Int => i + sums.toInt }, { i: Double => i + sums }))
+    }
   }
 
   val subtraction = Directive { case (a@Subtraction(_), childResults) =>
-    val results = childResults.reduce({ (res1: Result, res2: Result) =>
-      (res1, res2) match {
-        case (TileResult(lt1), TileResult(lt2)) => TileResult(LazyTile.DualCombine(List(lt1, lt2), {_ - _}, {_ - _}))
-        case (IntResult(int), TileResult(lt2)) => TileResult(LazyTile.DualMap(List(lt2), {int - _}, {int.toDouble - _}))
-        case (TileResult(lt1), IntResult(int)) => TileResult(LazyTile.DualMap(List(lt1), {_ - int}, {_ - int.toDouble}))
-        case (DoubleResult(dbl), TileResult(lt2)) => TileResult(LazyTile.DualMap(List(lt2), {dbl.toInt - _}, {dbl - _}))
-        case (TileResult(lt1), DoubleResult(dbl)) => TileResult(LazyTile.DualMap(List(lt1), {_ - dbl.toInt}, {_ - dbl}))
-        case (IntResult(int1), IntResult(int2)) => IntResult(int1 - int2)
-        case (DoubleResult(dbl1), DoubleResult(dbl2)) => DoubleResult(dbl1 - dbl2)
-        case (IntResult(int), DoubleResult(dbl)) => DoubleResult(int - dbl)
-        case (DoubleResult(dbl), IntResult(int)) => DoubleResult(dbl - int)
-      }
+    val results = childResults.reduce({ (res1, res2) =>
+      tileReduction({_ - _}, {_ -: _}, {_ - _}, {_ -: _}, {_ - _}, res1, res2)
     })
     Valid(results)
   }
 
   val division = Directive { case (a@Division(_), childResults) =>
     val results = childResults.reduce({ (res1: Result, res2: Result) =>
-      (res1, res2) match {
-        case (TileResult(lt1), TileResult(lt2)) => TileResult(LazyTile.DualCombine(List(lt1, lt2), {_ / _}, {_ / _}))
-        case (IntResult(int), TileResult(lt2)) => TileResult(LazyTile.DualMap(List(lt2), {int / _}, {int.toDouble / _}))
-        case (TileResult(lt), IntResult(int)) => TileResult(LazyTile.DualMap(List(lt), {_ / int}, {_ / int.toDouble}))
-        case (DoubleResult(dbl), TileResult(lt)) => TileResult(LazyTile.DualMap(List(lt), {dbl.toInt / _}, {dbl / _}))
-        case (TileResult(lt), DoubleResult(dbl)) => TileResult(LazyTile.DualMap(List(lt), {_ / dbl.toInt}, {_ / dbl}))
-        case (IntResult(int1), IntResult(int2)) => IntResult(int1 / int2)
-        case (DoubleResult(dbl1), DoubleResult(dbl2)) => DoubleResult(dbl1 / dbl2)
-        case (IntResult(int), DoubleResult(dbl)) => DoubleResult(int / dbl)
-        case (DoubleResult(dbl), IntResult(int)) => DoubleResult(dbl / int)
-      }
+      tileReduction({_ / _}, {_ /: _}, {_ / _}, {_ /: _}, {_ / _}, res1, res2)
     })
     Valid(results)
   }
@@ -89,33 +135,24 @@ object OpDirectives {
       .toList.sequence
       .andThen({ results => Valid(DoubleResult(results.reduce(_ * _))) })
   }
+
   val multiplicationInt = Directive { case (a@Multiplication(_), childResults) if (a.kind == MamlKind.Double) =>
     childResults
       .map({ _.as[Double] })
       .toList.sequence
       .andThen({ results => Valid(DoubleResult(results.reduce(_ * _))) })
   }
-  val multiplicationTile = Directive { case (a@Multiplication(_), childResults) if (a.kind == MamlKind.Tile) =>
-    val grouped = childResults
-      .groupBy(_.kind)
-    val dblRes: Interpreted[List[Double]] =
-      grouped.getOrElse(MamlKind.Double, List.empty)
-        .map({ _.as[Double] })
-        .toList.sequence
-    val intRes: Interpreted[List[Int]] =
-      grouped.getOrElse(MamlKind.Int, List.empty)
-        .map({ _.as[Int] })
-        .toList.sequence
-    val tileRes: Interpreted[List[LazyTile]] =
-      grouped(MamlKind.Tile)
-        .map({ _.as[LazyTile] })
-        .toList.sequence
 
-    (dblRes |@| intRes |@| tileRes).map({ case (dbls, ints, tiles) =>
-      val tileSum = tiles.reduce({ (lt1: LazyTile, lt2: LazyTile) => LazyTile.DualCombine(List(lt1, lt2), {_ * _}, {_ * _}) })
-      val scalarSum: Double = dbls.reduce(_ * _) + ints.reduce(_ * _)
-      TileResult(LazyTile.DualMap(List(tileSum), { i: Int => i * scalarSum.toInt }, { i: Double => i * scalarSum }))
-    })
+  val multiplicationTile = Directive { case (a@Multiplication(_), childResults) if (a.kind == MamlKind.Tile) =>
+    val grouped = childResults.groupBy(_.kind)
+
+    val scalarProduct =
+      (doubleResults(grouped) |@| intResults(grouped)).map { case (dbls, ints) => dbls.product * ints.product }
+
+    (lazytileResults(grouped) |@| scalarProduct).map { case (tiles, product) =>
+      val tileProduct = tiles.reduce({ (lt1: LazyTile, lt2: LazyTile) => LazyTile.DualCombine(List(lt1, lt2), {_ * _}, {_ * _}) })
+      TileResult(LazyTile.DualMap(List(tileProduct), { i: Int => i * product.toInt }, { i: Double => i * product }))
+    }
   }
 
   val maxDouble = Directive { case (a@Max(_), childResults) if (a.kind == MamlKind.Double) =>
@@ -124,32 +161,35 @@ object OpDirectives {
       .toList.sequence
       .andThen({ results => Valid(DoubleResult(results.reduce(_ max _))) })
   }
+
   val maxInt = Directive { case (a@Max(_), childResults) if (a.kind == MamlKind.Double) =>
     childResults
       .map({ _.as[Double] })
       .toList.sequence
       .andThen({ results => Valid(DoubleResult(results.reduce(_ max _))) })
   }
-  val maxTile = Directive { case (a@Max(_), childResults) if (a.kind == MamlKind.Tile) =>
-    val grouped = childResults
-      .groupBy(_.kind)
-    val dblRes: Interpreted[List[Double]] =
-      grouped(MamlKind.Double)
-        .map({ _.as[Double] })
-        .toList.sequence
-    val intRes: Interpreted[List[Int]] =
-      grouped(MamlKind.Int)
-        .map({ _.as[Int] })
-        .toList.sequence
-    val tileRes: Interpreted[List[LazyTile]] =
-      grouped(MamlKind.Tile)
-        .map({ _.as[LazyTile] })
-        .toList.sequence
 
-    (dblRes |@| intRes |@| tileRes).map({ case (dbls, ints, tiles) =>
+  val maxTile = Directive { case (a@Max(_), childResults) if (a.kind == MamlKind.Tile) =>
+    val grouped = childResults.groupBy(_.kind)
+
+    val scalarMax: Interpreted[Option[Double]] =
+      (doubleResults(grouped) |@| intResults(grouped)).map { case (dbls, ints) =>
+        (Try(dbls.max).toOption, Try(ints.max).toOption) match {
+          case (Some(dbl), Some(int)) => Some(dbl max int)
+          case (None, Some(int)) => Some(int)
+          case (Some(dbl), None) => Some(dbl)
+          case _ => None
+        }
+      }
+
+    (lazytileResults(grouped) |@| scalarMax).map({ case (tiles, maximum) =>
       val tileMax = tiles.reduce({ (lt1: LazyTile, lt2: LazyTile) => LazyTile.DualCombine(List(lt1, lt2), {_ max _}, {_ max _}) })
-      val scalarMax: Double = dbls.reduce(_ max _) + ints.reduce(_ max _)
-      TileResult(LazyTile.DualMap(List(tileMax), { i: Int => i max scalarMax.toInt }, { i: Double => i max scalarMax }))
+      maximum match {
+        case Some(scalarMax) =>
+          TileResult(LazyTile.DualMap(List(tileMax), { i: Int => i max scalarMax.toInt }, { i: Double => i max scalarMax }))
+        case None =>
+          TileResult(tileMax)
+      }
     })
   }
 
@@ -159,121 +199,101 @@ object OpDirectives {
       .toList.sequence
       .andThen({ results => Valid(DoubleResult(results.reduce(_ min _))) })
   }
+
   val minInt = Directive { case (a@Min(_), childResults) if (a.kind == MamlKind.Double) =>
     childResults
       .map({ _.as[Double] })
       .toList.sequence
       .andThen({ results => Valid(DoubleResult(results.reduce(_ min _))) })
   }
-  val minTile = Directive { case (a@Min(_), childResults) if (a.kind == MamlKind.Tile) =>
-    val grouped = childResults
-      .groupBy(_.kind)
-    val dblRes: Interpreted[List[Double]] =
-      grouped.getOrElse(MamlKind.Double, List.empty)
-        .map({ _.as[Double] })
-        .toList.sequence
-    val intRes: Interpreted[List[Int]] =
-      grouped.getOrElse(MamlKind.Int, List.empty)
-        .map({ _.as[Int] })
-        .toList.sequence
-    val tileRes: Interpreted[List[LazyTile]] =
-      grouped(MamlKind.Tile)
-        .map({ _.as[LazyTile] })
-        .toList.sequence
 
-    (dblRes |@| intRes |@| tileRes).map({ case (dbls, ints, tiles) =>
+  val minTile = Directive { case (a@Min(_), childResults) if (a.kind == MamlKind.Tile) =>
+    val grouped = childResults.groupBy(_.kind)
+
+    val scalarMin: Interpreted[Option[Double]] =
+      (doubleResults(grouped) |@| intResults(grouped)).map { case (dbls, ints) =>
+        (Try(dbls.min).toOption, Try(ints.min).toOption) match {
+          case (Some(dbl), Some(int)) => Some(dbl min int)
+          case (None, Some(int)) => Some(int)
+          case (Some(dbl), None) => Some(dbl)
+          case _ => None
+        }
+      }
+
+    (lazytileResults(grouped) |@| scalarMin).map({ case (tiles, minimum) =>
       val tileMin = tiles.reduce({ (lt1: LazyTile, lt2: LazyTile) => LazyTile.DualCombine(List(lt1, lt2), {_ min _}, {_ min _}) })
-      val scalarMin: Double = dbls.reduce(_ min _) + ints.reduce(_ min _)
-      TileResult(LazyTile.DualMap(List(tileMin), { i: Int => i min scalarMin.toInt }, { i: Double => i min scalarMin }))
+      minimum match {
+        case Some(scalarMin) =>
+          TileResult(LazyTile.DualMap(List(tileMin), { i: Int => i min scalarMin.toInt }, { i: Double => i min scalarMin }))
+        case None =>
+          TileResult(tileMin)
+      }
     })
   }
 
+  /** Numeric Comparison Operations */
   val lessThan = Directive { case (a@Less(_), childResults) =>
-    import geotrellis.raster.mapalgebra.local.Less.compare
     val results = childResults.reduce({ (res1: Result, res2: Result) =>
-      (res1, res2) match {
-        case (TileResult(lt1), TileResult(lt2)) => TileResult(LazyTile.DualCombine(List(lt1, lt2), {(p: Int, q: Int) => if (compare(p, q)) 1 else 0}, {(p: Double, q: Double) => if (compare(p, q)) 1.0 else 0.0}))
-        case (IntResult(int), TileResult(lt2)) => TileResult(LazyTile.DualMap(List(lt2), {p: Int => if (compare(int, p)) 1 else 0}, {p: Double => if (compare(int.toDouble, p)) 1.0 else 0.0}))
-        case (TileResult(lt), IntResult(int)) => TileResult(LazyTile.DualMap(List(lt), {p: Int => if (compare(p, int)) 1 else 0}, {p: Double => if (compare(p, int.toDouble)) 1.0 else 0.0}))
-        case (DoubleResult(dbl), TileResult(lt)) => TileResult(LazyTile.DualMap(List(lt), {p: Int => if (compare(dbl.toInt, p)) 1 else 0}, {p: Double => if (compare(dbl, p)) 1.0 else 0.0}))
-        case (TileResult(lt), DoubleResult(dbl)) => TileResult(LazyTile.DualMap(List(lt), {p: Int => if (compare(p, dbl.toInt)) 1 else 0}, {p: Double => if (compare(p, dbl)) 1.0 else 0.0}))
-        case (IntResult(int1), IntResult(int2)) => BoolResult(compare(int1, int2))
-        case (DoubleResult(dbl1), DoubleResult(dbl2)) => BoolResult(compare(dbl1, dbl2))
-        case (IntResult(int), DoubleResult(dbl)) => BoolResult(compare(int, dbl))
-        case (DoubleResult(dbl), IntResult(int)) => BoolResult(compare(dbl, int))
-      }
+      tileOrBoolReduction(
+        {_ < _}, { (i, t) => t < i }, {_ < _}, { (d, t) => t < d }, {_ < _},
+        {_ < _}, {_ < _}, {_ < _}, {_ < _.toInt},
+        res1, res2
+      )
     })
     Valid(results)
   }
 
   val lessThanOrEqualTo = Directive { case (a@LessOrEqual(_), childResults) =>
-    import geotrellis.raster.mapalgebra.local.LessOrEqual.compare
     val results = childResults.reduce({ (res1: Result, res2: Result) =>
-      (res1, res2) match {
-        case (TileResult(lt1), TileResult(lt2)) => TileResult(LazyTile.DualCombine(List(lt1, lt2), {(p: Int, q: Int) => if (compare(p, q)) 1 else 0}, {(p: Double, q: Double) => if (compare(p, q)) 1.0 else 0.0}))
-        case (IntResult(int), TileResult(lt2)) => TileResult(LazyTile.DualMap(List(lt2), {p: Int => if (compare(int, p)) 1 else 0}, {p: Double => if (compare(int.toDouble, p)) 1.0 else 0.0}))
-        case (TileResult(lt), IntResult(int)) => TileResult(LazyTile.DualMap(List(lt), {p: Int => if (compare(p, int)) 1 else 0}, {p: Double => if (compare(p, int.toDouble)) 1.0 else 0.0}))
-        case (DoubleResult(dbl), TileResult(lt)) => TileResult(LazyTile.DualMap(List(lt), {p: Int => if (compare(dbl.toInt, p)) 1 else 0}, {p: Double => if (compare(dbl, p)) 1.0 else 0.0}))
-        case (TileResult(lt), DoubleResult(dbl)) => TileResult(LazyTile.DualMap(List(lt), {p: Int => if (compare(p, dbl.toInt)) 1 else 0}, {p: Double => if (compare(p, dbl)) 1.0 else 0.0}))
-        case (IntResult(int1), IntResult(int2)) => BoolResult(compare(int1, int2))
-        case (DoubleResult(dbl1), DoubleResult(dbl2)) => BoolResult(compare(dbl1, dbl2))
-        case (IntResult(int), DoubleResult(dbl)) => BoolResult(compare(int, dbl))
-        case (DoubleResult(dbl), IntResult(int)) => BoolResult(compare(dbl, int))
-      }
+      tileOrBoolReduction(
+        {_ <= _}, { (i, t) => t <= i }, {_ <= _}, { (d, t) => t <= d }, {_ <= _},
+        {_ <= _}, {_ <= _}, {_ <= _}, {_ <= _.toInt},
+        res1, res2
+      )
     })
     Valid(results)
   }
 
   val equalTo = Directive { case (a@Equal(_), childResults) =>
-    import geotrellis.raster.mapalgebra.local.Equal.compare
     val results = childResults.reduce({ (res1: Result, res2: Result) =>
-      (res1, res2) match {
-        case (TileResult(lt1), TileResult(lt2)) => TileResult(LazyTile.DualCombine(List(lt1, lt2), {(p: Int, q: Int) => if (compare(p, q)) 1 else 0}, {(p: Double, q: Double) => if (compare(p, q)) 1.0 else 0.0}))
-        case (IntResult(int), TileResult(lt2)) => TileResult(LazyTile.DualMap(List(lt2), {p: Int => if (compare(int, p)) 1 else 0}, {p: Double => if (compare(int.toDouble, p)) 1.0 else 0.0}))
-        case (TileResult(lt), IntResult(int)) => TileResult(LazyTile.DualMap(List(lt), {p: Int => if (compare(p, int)) 1 else 0}, {p: Double => if (compare(p, int.toDouble)) 1.0 else 0.0}))
-        case (DoubleResult(dbl), TileResult(lt)) => TileResult(LazyTile.DualMap(List(lt), {p: Int => if (compare(dbl.toInt, p)) 1 else 0}, {p: Double => if (compare(dbl, p)) 1.0 else 0.0}))
-        case (TileResult(lt), DoubleResult(dbl)) => TileResult(LazyTile.DualMap(List(lt), {p: Int => if (compare(p, dbl.toInt)) 1 else 0}, {p: Double => if (compare(p, dbl)) 1.0 else 0.0}))
-        case (IntResult(int1), IntResult(int2)) => BoolResult(compare(int1, int2))
-        case (DoubleResult(dbl1), DoubleResult(dbl2)) => BoolResult(compare(dbl1, dbl2))
-        case (IntResult(int), DoubleResult(dbl)) => BoolResult(compare(int, dbl))
-        case (DoubleResult(dbl), IntResult(int)) => BoolResult(compare(dbl, int))
-      }
+      tileOrBoolReduction(
+        {_ === _}, { (i, t) => t === i }, {_ === _}, { (d, t) => t === d }, {_ === _},
+        {_ == _}, {_ == _}, {_ == _}, {_ == _.toInt},
+        res1, res2
+      )
+    })
+    Valid(results)
+  }
+
+  val notEqualTo = Directive { case (a@Equal(_), childResults) =>
+    val results = childResults.reduce({ (res1: Result, res2: Result) =>
+      tileOrBoolReduction(
+        {_ !== _}, { (i, t) => t !== i }, {_ !== _}, { (d, t) => t !== d }, {_ !== _},
+        {_ != _}, {_ != _}, {_ != _}, {_ != _.toInt},
+        res1, res2
+      )
     })
     Valid(results)
   }
 
   val greaterThan = Directive { case (a@Greater(_), childResults) =>
-    import geotrellis.raster.mapalgebra.local.Greater.compare
     val results = childResults.reduce({ (res1: Result, res2: Result) =>
-      (res1, res2) match {
-        case (TileResult(lt1), TileResult(lt2)) => TileResult(LazyTile.DualCombine(List(lt1, lt2), {(p: Int, q: Int) => if (compare(p, q)) 1 else 0}, {(p: Double, q: Double) => if (compare(p, q)) 1.0 else 0.0}))
-        case (IntResult(int), TileResult(lt2)) => TileResult(LazyTile.DualMap(List(lt2), {p: Int => if (compare(int, p)) 1 else 0}, {p: Double => if (compare(int.toDouble, p)) 1.0 else 0.0}))
-        case (TileResult(lt), IntResult(int)) => TileResult(LazyTile.DualMap(List(lt), {p: Int => if (compare(p, int)) 1 else 0}, {p: Double => if (compare(p, int.toDouble)) 1.0 else 0.0}))
-        case (DoubleResult(dbl), TileResult(lt)) => TileResult(LazyTile.DualMap(List(lt), {p: Int => if (compare(dbl.toInt, p)) 1 else 0}, {p: Double => if (compare(dbl, p)) 1.0 else 0.0}))
-        case (TileResult(lt), DoubleResult(dbl)) => TileResult(LazyTile.DualMap(List(lt), {p: Int => if (compare(p, dbl.toInt)) 1 else 0}, {p: Double => if (compare(p, dbl)) 1.0 else 0.0}))
-        case (IntResult(int1), IntResult(int2)) => BoolResult(compare(int1, int2))
-        case (DoubleResult(dbl1), DoubleResult(dbl2)) => BoolResult(compare(dbl1, dbl2))
-        case (IntResult(int), DoubleResult(dbl)) => BoolResult(compare(int, dbl))
-        case (DoubleResult(dbl), IntResult(int)) => BoolResult(compare(dbl, int))
-      }
+      tileOrBoolReduction(
+        {_ > _}, { (i, t) => t > i }, {_ > _}, { (d, t) => t > d }, {_ > _},
+        {_ > _}, {_ > _}, {_ > _}, {_ > _.toInt},
+        res1, res2
+      )
     })
     Valid(results)
   }
 
   val greaterThanOrEqualTo = Directive { case (a@GreaterOrEqual(_), childResults) =>
-    import geotrellis.raster.mapalgebra.local.GreaterOrEqual.compare
     val results = childResults.reduce({ (res1: Result, res2: Result) =>
-      (res1, res2) match {
-        case (TileResult(lt1), TileResult(lt2)) => TileResult(LazyTile.DualCombine(List(lt1, lt2), {(p: Int, q: Int) => if (compare(p, q)) 1 else 0}, {(p: Double, q: Double) => if (compare(p, q)) 1.0 else 0.0}))
-        case (IntResult(int), TileResult(lt2)) => TileResult(LazyTile.DualMap(List(lt2), {p: Int => if (compare(int, p)) 1 else 0}, {p: Double => if (compare(int.toDouble, p)) 1.0 else 0.0}))
-        case (TileResult(lt), IntResult(int)) => TileResult(LazyTile.DualMap(List(lt), {p: Int => if (compare(p, int)) 1 else 0}, {p: Double => if (compare(p, int.toDouble)) 1.0 else 0.0}))
-        case (DoubleResult(dbl), TileResult(lt)) => TileResult(LazyTile.DualMap(List(lt), {p: Int => if (compare(dbl.toInt, p)) 1 else 0}, {p: Double => if (compare(dbl, p)) 1.0 else 0.0}))
-        case (TileResult(lt), DoubleResult(dbl)) => TileResult(LazyTile.DualMap(List(lt), {p: Int => if (compare(p, dbl.toInt)) 1 else 0}, {p: Double => if (compare(p, dbl)) 1.0 else 0.0}))
-        case (IntResult(int1), IntResult(int2)) => BoolResult(compare(int1, int2))
-        case (DoubleResult(dbl1), DoubleResult(dbl2)) => BoolResult(compare(dbl1, dbl2))
-        case (IntResult(int), DoubleResult(dbl)) => BoolResult(compare(int, dbl))
-        case (DoubleResult(dbl), IntResult(int)) => BoolResult(compare(dbl, int))
-      }
+      tileOrBoolReduction(
+        {_ >= _}, { (i, t) => t > i }, {_ >= _}, { (d, t) => t > d }, {_ >= _},
+        {_ >= _}, {_ >= _}, {_ >= _}, {_ >= _.toInt},
+        res1, res2
+      )
     })
     Valid(results)
   }

--- a/jvm/src/main/scala/eval/directive/OpDirectives.scala
+++ b/jvm/src/main/scala/eval/directive/OpDirectives.scala
@@ -28,69 +28,72 @@ object OpDirectives {
 
   private def not[A, B](f: (A, B) => Boolean): (A, B) => Boolean = !f(_, _)
 
-   private def tileReduction(
-     ti: (LazyTile, Int) => LazyTile,
-     it: (Int, LazyTile) => LazyTile,
-     td: (LazyTile, Double) => LazyTile,
-     dt: (Double, LazyTile) => LazyTile,
-     tt: (LazyTile, LazyTile) => LazyTile,
-     res1: Result,
-     res2: Result
-   ): Result = (res1, res2) match {
-     case (TileResult(lt1), TileResult(lt2)) => TileResult(tt(lt1, lt2))
-     case (TileResult(lt), IntResult(int)) => TileResult((ti(lt, int)))
-     case (IntResult(int), TileResult(lt)) => TileResult((it(int, lt)))
-     case (TileResult(lt), DoubleResult(double)) => TileResult(td(lt, double))
-     case (DoubleResult(double), TileResult(lt)) => TileResult(dt(double, lt))
-   }
+  private def tileReduction(
+    ti: (LazyTile, Int) => LazyTile,
+    it: (Int, LazyTile) => LazyTile,
+    td: (LazyTile, Double) => LazyTile,
+    dt: (Double, LazyTile) => LazyTile,
+    tt: (LazyTile, LazyTile) => LazyTile,
+    res1: Result,
+    res2: Result
+  ): Result = (res1, res2) match {
+    case (TileResult(lt1), TileResult(lt2)) => TileResult(tt(lt1, lt2))
+    case (TileResult(lt), IntResult(int)) => TileResult((ti(lt, int)))
+    case (IntResult(int), TileResult(lt)) => TileResult((it(int, lt)))
+    case (TileResult(lt), DoubleResult(double)) => TileResult(td(lt, double))
+    case (DoubleResult(double), TileResult(lt)) => TileResult(dt(double, lt))
+    case (x, y) =>
+      println(x, y, "testing")
+      throw new Exception {}
+  }
 
-   private def tileOrBoolReduction(
-     ti: (LazyTile, Int) => LazyTile,
-     it: (Int, LazyTile) => LazyTile,
-     td: (LazyTile, Double) => LazyTile,
-     dt: (Double, LazyTile) => LazyTile,
-     tt: (LazyTile, LazyTile) => LazyTile,
-     ii: (Int, Int) => Boolean,
-     di: (Double, Int) => Boolean,
-     dd: (Double, Double) => Boolean,
-     id: (Int, Double) => Boolean,
-     res1: Result,
-     res2: Result
-   ): Result = (res1, res2) match {
-     case (TileResult(lt1), TileResult(lt2)) => TileResult(tt(lt1, lt2))
-     case (TileResult(lt), IntResult(int)) => TileResult((ti(lt, int)))
-     case (IntResult(int), TileResult(lt)) => TileResult((it(int, lt)))
-     case (TileResult(lt), DoubleResult(double)) => TileResult(td(lt, double))
-     case (DoubleResult(double), TileResult(lt)) => TileResult(dt(double, lt))
-     case (IntResult(int1), IntResult(int2)) => BoolResult(ii(int1, int2))
-     case (DoubleResult(dbl), IntResult(int)) => BoolResult(di(dbl, int))
-     case (DoubleResult(dbl1), DoubleResult(dbl2)) => BoolResult(dd(dbl1, dbl2))
-     case (IntResult(int), DoubleResult(dbl)) => BoolResult(id(int, dbl))
-   }
+  private def tileOrBoolReduction(
+   ti: (LazyTile, Int) => LazyTile,
+   it: (Int, LazyTile) => LazyTile,
+   td: (LazyTile, Double) => LazyTile,
+   dt: (Double, LazyTile) => LazyTile,
+   tt: (LazyTile, LazyTile) => LazyTile,
+   ii: (Int, Int) => Boolean,
+   di: (Double, Int) => Boolean,
+   dd: (Double, Double) => Boolean,
+   id: (Int, Double) => Boolean,
+   res1: Result,
+   res2: Result
+  ): Result = (res1, res2) match {
+   case (TileResult(lt1), TileResult(lt2)) => TileResult(tt(lt1, lt2))
+   case (TileResult(lt), IntResult(int)) => TileResult((ti(lt, int)))
+   case (IntResult(int), TileResult(lt)) => TileResult((it(int, lt)))
+   case (TileResult(lt), DoubleResult(double)) => TileResult(td(lt, double))
+   case (DoubleResult(double), TileResult(lt)) => TileResult(dt(double, lt))
+   case (IntResult(int1), IntResult(int2)) => BoolResult(ii(int1, int2))
+   case (DoubleResult(dbl), IntResult(int)) => BoolResult(di(dbl, int))
+   case (DoubleResult(dbl1), DoubleResult(dbl2)) => BoolResult(dd(dbl1, dbl2))
+   case (IntResult(int), DoubleResult(dbl)) => BoolResult(id(int, dbl))
+  }
 
-   private def tileOrScalarReduction(
-     ti: (LazyTile, Int) => LazyTile,
-     it: (Int, LazyTile) => LazyTile,
-     td: (LazyTile, Double) => LazyTile,
-     dt: (Double, LazyTile) => LazyTile,
-     tt: (LazyTile, LazyTile) => LazyTile,
-     ii: (Int, Int) => Int,
-     di: (Double, Int) => Double,
-     dd: (Double, Double) => Double,
-     id: (Int, Double) => Double,
-     res1: Result,
-     res2: Result
-   ): Result = (res1, res2) match {
-     case (TileResult(lt1), TileResult(lt2)) => TileResult(tt(lt1, lt2))
-     case (TileResult(lt), IntResult(int)) => TileResult((ti(lt, int)))
-     case (IntResult(int), TileResult(lt)) => TileResult((it(int, lt)))
-     case (TileResult(lt), DoubleResult(double)) => TileResult(td(lt, double))
-     case (DoubleResult(double), TileResult(lt)) => TileResult(dt(double, lt))
-     case (IntResult(int1), IntResult(int2)) => IntResult(ii(int1, int2))
-     case (DoubleResult(dbl), IntResult(int)) => DoubleResult(di(dbl, int))
-     case (DoubleResult(dbl1), DoubleResult(dbl2)) => DoubleResult(dd(dbl1, dbl2))
-     case (IntResult(int), DoubleResult(dbl)) => DoubleResult(id(int, dbl))
-   }
+  private def tileOrScalarReduction(
+   ti: (LazyTile, Int) => LazyTile,
+   it: (Int, LazyTile) => LazyTile,
+   td: (LazyTile, Double) => LazyTile,
+   dt: (Double, LazyTile) => LazyTile,
+   tt: (LazyTile, LazyTile) => LazyTile,
+   ii: (Int, Int) => Int,
+   di: (Double, Int) => Double,
+   dd: (Double, Double) => Double,
+   id: (Int, Double) => Double,
+   res1: Result,
+   res2: Result
+  ): Result = (res1, res2) match {
+   case (TileResult(lt1), TileResult(lt2)) => TileResult(tt(lt1, lt2))
+   case (TileResult(lt), IntResult(int)) => TileResult((ti(lt, int)))
+   case (IntResult(int), TileResult(lt)) => TileResult((it(int, lt)))
+   case (TileResult(lt), DoubleResult(double)) => TileResult(td(lt, double))
+   case (DoubleResult(double), TileResult(lt)) => TileResult(dt(double, lt))
+   case (IntResult(int1), IntResult(int2)) => IntResult(ii(int1, int2))
+   case (DoubleResult(dbl), IntResult(int)) => DoubleResult(di(dbl, int))
+   case (DoubleResult(dbl1), DoubleResult(dbl2)) => DoubleResult(dd(dbl1, dbl2))
+   case (IntResult(int), DoubleResult(dbl)) => DoubleResult(id(int, dbl))
+  }
 
   /** Arithmetic Operations */
   val additionDouble = Directive { case (a@Addition(_), childResults) if (a.kind == MamlKind.Double) =>
@@ -121,14 +124,20 @@ object OpDirectives {
 
   val subtraction = Directive { case (a@Subtraction(_), childResults) =>
     val results = childResults.reduce({ (res1, res2) =>
-      tileReduction({_ - _}, {_ -: _}, {_ - _}, {_ -: _}, {_ - _}, res1, res2)
+      tileOrScalarReduction(
+        {_ - _}, {_ -: _}, {_ - _}, {_ -: _}, {_ - _},
+        {_ - _}, {_ - _}, {_ - _}, {_ - _},
+        res1, res2)
     })
     Valid(results)
   }
 
   val division = Directive { case (a@Division(_), childResults) =>
     val results = childResults.reduce({ (res1: Result, res2: Result) =>
-      tileReduction({_ / _}, {_ /: _}, {_ / _}, {_ /: _}, {_ / _}, res1, res2)
+      tileOrScalarReduction(
+        {_ / _}, {_ /: _}, {_ / _}, {_ /: _}, {_ / _},
+        {_ / _}, {_ / _}, {_ / _}, {_ / _},
+        res1, res2)
     })
     Valid(results)
   }
@@ -174,121 +183,121 @@ object OpDirectives {
   }
 
   val maxTile = Directive { case (a@Max(_), childResults) if (a.kind == MamlKind.Tile) =>
-    val grouped = childResults.groupBy(_.kind)
+  val grouped = childResults.groupBy(_.kind)
 
-    val scalarMax: Interpreted[Option[Double]] =
-      (doubleResults(grouped) |@| intResults(grouped)).map { case (dbls, ints) =>
-        (Try(dbls.max).toOption, Try(ints.max).toOption) match {
-          case (Some(dbl), Some(int)) => Some(dbl max int)
-          case (None, Some(int)) => Some(int)
-          case (Some(dbl), None) => Some(dbl)
-          case _ => None
-        }
+  val scalarMax: Interpreted[Option[Double]] =
+    (doubleResults(grouped) |@| intResults(grouped)).map { case (dbls, ints) =>
+      (Try(dbls.max).toOption, Try(ints.max).toOption) match {
+        case (Some(dbl), Some(int)) => Some(dbl max int)
+        case (None, Some(int)) => Some(int)
+        case (Some(dbl), None) => Some(dbl)
+        case _ => None
       }
+    }
 
-    (lazytileResults(grouped) |@| scalarMax).map({ case (tiles, maximum) =>
-      val tileMax = tiles.reduce({ (lt1: LazyTile, lt2: LazyTile) => LazyTile.DualCombine(List(lt1, lt2), {_ max _}, {_ max _}) })
-      maximum match {
-        case Some(scalarMax) =>
-          TileResult(LazyTile.DualMap(List(tileMax), { i: Int => i max scalarMax.toInt }, { i: Double => i max scalarMax }))
-        case None =>
-          TileResult(tileMax)
-      }
-    })
+  (lazytileResults(grouped) |@| scalarMax).map({ case (tiles, maximum) =>
+    val tileMax = tiles.reduce({ (lt1: LazyTile, lt2: LazyTile) => LazyTile.DualCombine(List(lt1, lt2), {_ max _}, {_ max _}) })
+    maximum match {
+      case Some(scalarMax) =>
+        TileResult(LazyTile.DualMap(List(tileMax), { i: Int => i max scalarMax.toInt }, { i: Double => i max scalarMax }))
+      case None =>
+        TileResult(tileMax)
+    }
+  })
   }
 
   val minDouble = Directive { case (a@Min(_), childResults) if (a.kind == MamlKind.Double) =>
-    childResults
-      .map({ _.as[Double] })
-      .toList.sequence
-      .andThen({ results => Valid(DoubleResult(results.reduce(_ min _))) })
+  childResults
+    .map({ _.as[Double] })
+    .toList.sequence
+    .andThen({ results => Valid(DoubleResult(results.reduce(_ min _))) })
   }
 
   val minInt = Directive { case (a@Min(_), childResults) if (a.kind == MamlKind.Double) =>
-    childResults
-      .map({ _.as[Double] })
-      .toList.sequence
-      .andThen({ results => Valid(DoubleResult(results.reduce(_ min _))) })
+  childResults
+    .map({ _.as[Double] })
+    .toList.sequence
+    .andThen({ results => Valid(DoubleResult(results.reduce(_ min _))) })
   }
 
   val minTile = Directive { case (a@Min(_), childResults) if (a.kind == MamlKind.Tile) =>
-    val grouped = childResults.groupBy(_.kind)
+  val grouped = childResults.groupBy(_.kind)
 
-    val scalarMin: Interpreted[Option[Double]] =
-      (doubleResults(grouped) |@| intResults(grouped)).map { case (dbls, ints) =>
-        (Try(dbls.min).toOption, Try(ints.min).toOption) match {
-          case (Some(dbl), Some(int)) => Some(dbl min int)
-          case (None, Some(int)) => Some(int)
-          case (Some(dbl), None) => Some(dbl)
-          case _ => None
-        }
+  val scalarMin: Interpreted[Option[Double]] =
+    (doubleResults(grouped) |@| intResults(grouped)).map { case (dbls, ints) =>
+      (Try(dbls.min).toOption, Try(ints.min).toOption) match {
+        case (Some(dbl), Some(int)) => Some(dbl min int)
+        case (None, Some(int)) => Some(int)
+        case (Some(dbl), None) => Some(dbl)
+        case _ => None
       }
+    }
 
-    (lazytileResults(grouped) |@| scalarMin).map({ case (tiles, minimum) =>
-      val tileMin = tiles.reduce({ (lt1: LazyTile, lt2: LazyTile) => LazyTile.DualCombine(List(lt1, lt2), {_ min _}, {_ min _}) })
-      minimum match {
-        case Some(scalarMin) =>
-          TileResult(LazyTile.DualMap(List(tileMin), { i: Int => i min scalarMin.toInt }, { i: Double => i min scalarMin }))
-        case None =>
-          TileResult(tileMin)
-      }
-    })
+  (lazytileResults(grouped) |@| scalarMin).map({ case (tiles, minimum) =>
+    val tileMin = tiles.reduce({ (lt1: LazyTile, lt2: LazyTile) => LazyTile.DualCombine(List(lt1, lt2), {_ min _}, {_ min _}) })
+    minimum match {
+      case Some(scalarMin) =>
+        TileResult(LazyTile.DualMap(List(tileMin), { i: Int => i min scalarMin.toInt }, { i: Double => i min scalarMin }))
+      case None =>
+        TileResult(tileMin)
+    }
+  })
   }
 
   /** Numeric Comparison Operations */
   val lessThan = Directive { case (a@Less(_), childResults) =>
-    val results = childResults.reduce({ (res1: Result, res2: Result) =>
-      tileOrBoolReduction(
-        {_ < _}, { (i, t) => t < i }, {_ < _}, { (d, t) => t < d }, {_ < _},
-        {_ < _}, {_ < _}, {_ < _}, {_ < _.toInt},
-        res1, res2
-      )
-    })
-    Valid(results)
+  val results = childResults.reduce({ (res1: Result, res2: Result) =>
+    tileOrBoolReduction(
+      {_ < _}, { (i, t) => t < i }, {_ < _}, { (d, t) => t < d }, {_ < _},
+      {_ < _}, {_ < _}, {_ < _}, {_ < _.toInt},
+      res1, res2
+    )
+  })
+  Valid(results)
   }
 
   val lessThanOrEqualTo = Directive { case (a@LessOrEqual(_), childResults) =>
-    val results = childResults.reduce({ (res1: Result, res2: Result) =>
-      tileOrBoolReduction(
-        {_ <= _}, { (i, t) => t <= i }, {_ <= _}, { (d, t) => t <= d }, {_ <= _},
-        {_ <= _}, {_ <= _}, {_ <= _}, {_ <= _.toInt},
-        res1, res2
-      )
-    })
-    Valid(results)
+  val results = childResults.reduce({ (res1: Result, res2: Result) =>
+    tileOrBoolReduction(
+      {_ <= _}, { (i, t) => t <= i }, {_ <= _}, { (d, t) => t <= d }, {_ <= _},
+      {_ <= _}, {_ <= _}, {_ <= _}, {_ <= _.toInt},
+      res1, res2
+    )
+  })
+  Valid(results)
   }
 
   val equalTo = Directive { case (a@Equal(_), childResults) =>
-    val results = childResults.reduce({ (res1: Result, res2: Result) =>
-      tileOrBoolReduction(
-        {_ === _}, { (i, t) => t === i }, {_ === _}, { (d, t) => t === d }, {_ === _},
-        {_ == _}, {_ == _}, {_ == _}, {_ == _.toInt},
-        res1, res2
-      )
-    })
-    Valid(results)
+  val results = childResults.reduce({ (res1: Result, res2: Result) =>
+    tileOrBoolReduction(
+      {_ === _}, { (i, t) => t === i }, {_ === _}, { (d, t) => t === d }, {_ === _},
+      {_ == _}, {_ == _}, {_ == _}, {_ == _.toInt},
+      res1, res2
+    )
+  })
+  Valid(results)
   }
 
   val notEqualTo = Directive { case (a@Unequal(_), childResults) =>
-    val results = childResults.reduce({ (res1: Result, res2: Result) =>
-      tileOrBoolReduction(
-        {_ !== _}, { (i, t) => t !== i }, {_ !== _}, { (d, t) => t !== d }, {_ !== _},
-        {_ != _}, {_ != _}, {_ != _}, {_ != _.toInt},
-        res1, res2
-      )
-    })
-    Valid(results)
+  val results = childResults.reduce({ (res1: Result, res2: Result) =>
+    tileOrBoolReduction(
+      {_ !== _}, { (i, t) => t !== i }, {_ !== _}, { (d, t) => t !== d }, {_ !== _},
+      {_ != _}, {_ != _}, {_ != _}, {_ != _.toInt},
+      res1, res2
+    )
+  })
+  Valid(results)
   }
 
   val greaterThan = Directive { case (a@Greater(_), childResults) =>
-    val results = childResults.reduce({ (res1: Result, res2: Result) =>
-      tileOrBoolReduction(
-        {_ > _}, { (i, t) => t > i }, {_ > _}, { (d, t) => t > d }, {_ > _},
-        {_ > _}, {_ > _}, {_ > _}, {_ > _.toInt},
-        res1, res2
-      )
-    })
-    Valid(results)
+  val results = childResults.reduce({ (res1: Result, res2: Result) =>
+    tileOrBoolReduction(
+      {_ > _}, { (i, t) => t > i }, {_ > _}, { (d, t) => t > d }, {_ > _},
+      {_ > _}, {_ > _}, {_ > _}, {_ > _.toInt},
+      res1, res2
+    )
+  })
+  Valid(results)
   }
 
   val greaterThanOrEqualTo = Directive { case (a@GreaterOrEqual(_), childResults) =>

--- a/jvm/src/main/scala/eval/directive/OpDirectives.scala
+++ b/jvm/src/main/scala/eval/directive/OpDirectives.scala
@@ -28,25 +28,6 @@ object OpDirectives {
 
   private def not[A, B](f: (A, B) => Boolean): (A, B) => Boolean = !f(_, _)
 
-  private def tileReduction(
-    ti: (LazyTile, Int) => LazyTile,
-    it: (Int, LazyTile) => LazyTile,
-    td: (LazyTile, Double) => LazyTile,
-    dt: (Double, LazyTile) => LazyTile,
-    tt: (LazyTile, LazyTile) => LazyTile,
-    res1: Result,
-    res2: Result
-  ): Result = (res1, res2) match {
-    case (TileResult(lt1), TileResult(lt2)) => TileResult(tt(lt1, lt2))
-    case (TileResult(lt), IntResult(int)) => TileResult((ti(lt, int)))
-    case (IntResult(int), TileResult(lt)) => TileResult((it(int, lt)))
-    case (TileResult(lt), DoubleResult(double)) => TileResult(td(lt, double))
-    case (DoubleResult(double), TileResult(lt)) => TileResult(dt(double, lt))
-    case (x, y) =>
-      println(x, y, "testing")
-      throw new Exception {}
-  }
-
   private def tileOrBoolReduction(
    ti: (LazyTile, Int) => LazyTile,
    it: (Int, LazyTile) => LazyTile,

--- a/jvm/src/main/scala/eval/directive/SourceDirectives.scala
+++ b/jvm/src/main/scala/eval/directive/SourceDirectives.scala
@@ -20,11 +20,7 @@ object SourceDirectives {
 
   val boolLiteral = Directive { case (BoolLiteral(bool), _) => Valid(BoolResult(bool)) }
 
-  val tileLiteral = Directive { case (TileLiteral(tile), _) => Valid(TileResult(LazyTile(tile))) }
-
-  val bufferingTileLiteral = ScopedDirective[BufferingInterpreter.Scope] { case (TileLiteral(tile), _, scope) =>
-    Valid(TileResult(LazyTile(tile)))
-  }
+  val tileLiteral = Directive { case (TileLiteral(tile, extent), _) => Valid(TileResult(LazyTile(tile, extent))) }
 
   val geomJson = Directive { case (GeomJson(jsonString), _) =>
     Try(jsonString.parseGeoJson[Geometry]) match {

--- a/jvm/src/main/scala/eval/directive/SourceDirectives.scala
+++ b/jvm/src/main/scala/eval/directive/SourceDirectives.scala
@@ -4,9 +4,14 @@ import com.azavea.maml.eval._
 import com.azavea.maml.eval.tile._
 import com.azavea.maml.ast._
 
+import geotrellis.vector.io._
+import geotrellis.vector.Geometry
+import io.circe._
+import io.circe.parser._
 import cats.data.{NonEmptyList => NEL, _}
 import Validated._
 
+import scala.util.{Try, Success, Failure}
 
 object SourceDirectives {
   val intLiteral = Directive { case (IntLiteral(int), _) => Valid(IntResult(int)) }
@@ -20,4 +25,16 @@ object SourceDirectives {
   val bufferingTileLiteral = ScopedDirective[BufferingInterpreter.Scope] { case (TileLiteral(tile), _, scope) =>
     Valid(TileResult(LazyTile(tile)))
   }
+
+  val geomJson = Directive { case (GeomJson(jsonString), _) =>
+    Try(jsonString.parseGeoJson[Geometry]) match {
+      case Success(geom) => Valid(GeomResult(geom))
+      case Failure(e) =>
+        parse(jsonString) match {
+          case Right(json) => Invalid(NEL.of(ASTDecodeError(json, "provided JSON is not valid GeoJson")))
+          case Left(parsingFailure) => Invalid(NEL.of(ASTParseError(jsonString, parsingFailure.message)))
+        }
+    }
+  }
 }
+

--- a/jvm/src/main/scala/eval/directive/UnaryDirectives.scala
+++ b/jvm/src/main/scala/eval/directive/UnaryDirectives.scala
@@ -1,0 +1,132 @@
+package com.azavea.maml.eval.directive
+
+import com.azavea.maml.eval._
+import com.azavea.maml.eval.tile._
+import com.azavea.maml.ast._
+import com.azavea.maml.dsl.tile._
+
+import cats._
+import cats.implicits._
+import cats.data.{NonEmptyList => NEL, _}
+import Validated._
+import geotrellis.raster._
+
+import scala.util.Try
+
+
+object UnaryDirectives {
+
+  private def tileOrScalarResult(
+    t: LazyTile => LazyTile,
+    i: Int => Double,
+    d: Double => Double,
+    arg: Result
+  ): Result = arg match {
+    case TileResult(lt) => TileResult(t(lt))
+    case IntResult(int) => DoubleResult(i(int))
+    case DoubleResult(dbl) => DoubleResult(d(dbl))
+  }
+
+  private def tileOrBoolResult(
+    t: LazyTile => LazyTile,
+    i: Int => Boolean,
+    d: Double => Boolean,
+    arg: Result
+  ): Result = arg match {
+    case TileResult(lt) => TileResult(t(lt))
+    case IntResult(int) => BoolResult(i(int))
+    case DoubleResult(dbl) => BoolResult(d(dbl))
+  }
+
+  /** Trigonometric Operations */
+  val sin = Directive { case (s@Sin(_), childResults) =>
+    val result = tileOrScalarResult({ _.sin }, { math.sin(_) }, { math.sin(_) }, childResults.head)
+    Valid(result)
+  }
+
+  val cos = Directive { case (s@Cos(_), childResults) =>
+    val result = tileOrScalarResult({ _.cos }, { math.cos(_) }, { math.cos(_) }, childResults.head)
+    Valid(result)
+  }
+
+  val tan = Directive { case (s@Tan(_), childResults) =>
+    val result = tileOrScalarResult({ _.tan }, { math.tan(_) }, { math.tan(_) }, childResults.head)
+    Valid(result)
+  }
+
+  val sinh = Directive { case (s@Sinh(_), childResults) =>
+    val result = tileOrScalarResult({ _.sinh }, { math.sinh(_) }, { math.sinh(_) }, childResults.head)
+    Valid(result)
+  }
+
+  val cosh = Directive { case (s@Cosh(_), childResults) =>
+    val result = tileOrScalarResult({ _.cosh }, { math.cosh(_) }, { math.cosh(_) }, childResults.head)
+    Valid(result)
+  }
+
+  val tanh = Directive { case (s@Tanh(_), childResults) =>
+    val result = tileOrScalarResult({ _.tanh }, { math.tanh(_) }, { math.tanh(_) }, childResults.head)
+    Valid(result)
+  }
+
+  val asin = Directive { case (s@Asin(_), childResults) =>
+    val result = tileOrScalarResult({ _.asin }, { math.asin(_) }, { math.asin(_) }, childResults.head)
+    Valid(result)
+  }
+
+  val acos = Directive { case (s@Acos(_), childResults) =>
+    val result = tileOrScalarResult({ _.acos }, { math.acos(_) }, { math.acos(_) }, childResults.head)
+    Valid(result)
+  }
+
+  val atan = Directive { case (s@Atan(_), childResults) =>
+    val result = tileOrScalarResult({ _.atan }, { math.atan(_) }, { math.atan(_) }, childResults.head)
+    Valid(result)
+  }
+
+  /** Rounding Operations */
+  val round = Directive { case (r@Round(_), childResults) =>
+    val result = tileOrScalarResult({ _.round }, identity, { math.round(_) }, childResults.head)
+    Valid(result)
+  }
+  val floor = Directive { case (r@Floor(_), childResults) =>
+    val result = tileOrScalarResult({ _.floor }, identity, { math.floor(_) }, childResults.head)
+    Valid(result)
+  }
+  val ceil = Directive { case (r@Ceil(_), childResults) =>
+    val result = tileOrScalarResult({ _.ceil }, identity, { math.ceil(_) }, childResults.head)
+    Valid(result)
+  }
+
+  /** Specialty Arithmetic Operations */
+  val naturalLog = Directive { case  (nl@LogE(_), childResults) =>
+    val result = tileOrScalarResult({ _.logE }, { i: Int => math.log(i2d(i)) }, { math.log(_) }, childResults.head)
+    Valid(result)
+  }
+
+  val log10 = Directive { case  (nl@LogE(_), childResults) =>
+    val result = tileOrScalarResult({ _.log10 }, { i: Int => math.log10(i2d(i)) }, { math.log10(_) }, childResults.head)
+    Valid(result)
+  }
+
+  val sqrt = Directive { case  (sqrt@SquareRoot(_), childResults) =>
+    val result = tileOrScalarResult({ _.sqrt }, { i: Int => math.sqrt(i2d(i)) }, { math.sqrt(_) }, childResults.head)
+    Valid(result)
+  }
+
+  val abs = Directive { case  (sqrt@SquareRoot(_), childResults) =>
+    val result = tileOrScalarResult({ _.abs }, { i: Int => math.abs(i) }, { math.abs(_) }, childResults.head)
+    Valid(result)
+  }
+
+  val isDefined = Directive { case (d@Defined(_), childResults) =>
+    val result = tileOrBoolResult({ _.isDefined }, { i: Int => isData(i) }, { isData(_) }, childResults.head)
+    Valid(result)
+  }
+
+  val isUndefined = Directive { case (d@Defined(_), childResults) =>
+    val result = tileOrBoolResult({ _.isUndefined }, { i: Int => isNoData(i) }, { isNoData(_) }, childResults.head)
+    Valid(result)
+  }
+}
+

--- a/jvm/src/main/scala/eval/tile/LazyTile.scala
+++ b/jvm/src/main/scala/eval/tile/LazyTile.scala
@@ -19,6 +19,9 @@ import scala.reflect.ClassTag
 
 
 sealed trait LazyTile extends LazyLogging {
+  // TODO: We need to find a way to rip RasterExtent out of LazyTile
+  //       while still being able to provide it to Masking operations.
+  //       Is this a use case for futo or paramorphisms?
   def extent: RasterExtent
   def children: List[LazyTile]
   def cols: Int

--- a/jvm/src/main/scala/eval/tile/Masking.scala
+++ b/jvm/src/main/scala/eval/tile/Masking.scala
@@ -9,11 +9,11 @@ import geotrellis.vector.{ Extent, MultiPolygon, Point }
 import spire.syntax.cfor._
 
 
-case class MaskingNode(children: List[LazyTile], extent: Extent, mask: MultiPolygon) extends LazyTile.UnaryBranch {
+case class MaskingNode(children: List[LazyTile], mask: MultiPolygon) extends LazyTile.UnaryBranch {
   lazy val cellMask: Tile = {
     val masky = ArrayTile.empty(BitCellType, this.cols, this.rows)
 
-    RasterExtent(extent, this.cols, this.rows)
+    extent
       .foreach(mask)({ (col, row) => masky.set(col, row, 1) })
 
     masky

--- a/jvm/src/main/scala/eval/tile/TileLayouts.scala
+++ b/jvm/src/main/scala/eval/tile/TileLayouts.scala
@@ -1,0 +1,17 @@
+package com.azavea.maml.eval.tile
+
+import com.typesafe.scalalogging.LazyLogging
+import geotrellis.proj4.WebMercator
+import geotrellis.raster._
+import geotrellis.spark.tiling._
+
+
+/** This interpreter handles resource resolution and compilation of MapAlgebra ASTs */
+object TileLayouts extends LazyLogging {
+
+  private val layouts: Array[LayoutDefinition] = (0 to 30).map(n =>
+    ZoomedLayoutScheme.layoutForZoom(n, WebMercator.worldExtent, 256)
+  ).toArray
+
+  def apply(i: Int) = layouts(i)
+}

--- a/jvm/src/main/scala/serve/InterpreterExceptionHandling.scala
+++ b/jvm/src/main/scala/serve/InterpreterExceptionHandling.scala
@@ -10,8 +10,6 @@ import akka.http.scaladsl.server.{Directives, ExceptionHandler}
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 
 
-case class InterpreterException(errors: NonEmptyList[InterpreterError]) extends Exception
-
 trait InterpreterExceptionHandling extends Directives {
   val interpreterExceptionHandler = ExceptionHandler {
     case ie: InterpreterException =>

--- a/jvm/src/main/scala/serve/MamlService.scala
+++ b/jvm/src/main/scala/serve/MamlService.scala
@@ -57,13 +57,7 @@ trait Service extends InterpreterExceptionHandling {
 
   val cMap = ColorRamps.Viridis
 
-  val interpreter = Interpreter.buffering(
-    ScopedDirective.pure[TileLiteral](SourceDirectives.tileLiteral),
-    ScopedDirective.pure[IntLiteral](SourceDirectives.intLiteral),
-    ScopedDirective.pure[FocalMax](FocalDirectives.focalMax),
-    ScopedDirective.pure[Addition](OpDirectives.additionTile orElse OpDirectives.additionInt orElse OpDirectives.additionDouble),
-    ScopedDirective.pure[Equal](OpDirectives.equalTo)
-  )
+  val interpreter = BufferingInterpreter.DEFAULT
 
   implicit def encodeNEL[A: Encoder]: Encoder[NonEmptyList[A]] = Encoder.encodeList[A].contramap[NonEmptyList[A]](_.toList)
 

--- a/jvm/src/test/scala/eval/EvaluationSpec.scala
+++ b/jvm/src/test/scala/eval/EvaluationSpec.scala
@@ -11,6 +11,7 @@ import com.azavea.maml.ast.codec.tree.ExpressionTreeCodec
 import io.circe._
 import io.circe.syntax._
 import geotrellis.raster._
+import geotrellis.vector._
 import cats._
 import cats.data.{NonEmptyList => NEL, _}
 import Validated._
@@ -21,7 +22,7 @@ import scala.reflect._
 
 class EvaluationSpec extends FunSpec with Matchers with ExpressionTreeCodec {
 
-  implicit def tileIsTileLiteral(tile: Tile): TileLiteral = TileLiteral(tile)
+  implicit def tileIsTileLiteral(tile: Tile): TileLiteral = TileLiteral(tile, RasterExtent(tile, Extent(0, 0, 0, 0)))
 
   implicit class TypeRefinement(self: Interpreted[Result]) {
     def as[T: ClassTag]: Interpreted[T] = self match {
@@ -30,7 +31,7 @@ class EvaluationSpec extends FunSpec with Matchers with ExpressionTreeCodec {
     }
   }
 
-  val interpreter = Interpreter.naive(
+  val interpreter = NaiveInterpreter(List(
     intLiteral,
     dblLiteral,
     boolLiteral,
@@ -54,7 +55,7 @@ class EvaluationSpec extends FunSpec with Matchers with ExpressionTreeCodec {
     equalTo,
     greaterThanOrEqualTo,
     greaterThan
-  )
+  ))
 
   it("Should interpret and evaluate to Boolean literals") {
     interpreter(BoolLiteral(true)).as[Boolean] should be (Valid(true))
@@ -86,7 +87,6 @@ class EvaluationSpec extends FunSpec with Matchers with ExpressionTreeCodec {
   }
 
   it("Should interpret and evaluate comparisions with scalars") {
-    println((DoubleLiteral(20) < DoubleLiteral(20)).asJson.noSpaces)
     interpreter(DoubleLiteral(20) < DoubleLiteral(20)).as[Boolean] should be (Valid(false))
     interpreter(DoubleLiteral(19) < DoubleLiteral(20)).as[Boolean] should be (Valid(true))
     interpreter(DoubleLiteral(29) < DoubleLiteral(20)).as[Boolean] should be (Valid(false))

--- a/jvm/src/test/scala/eval/ResultSpec.scala
+++ b/jvm/src/test/scala/eval/ResultSpec.scala
@@ -7,6 +7,7 @@ import com.azavea.maml.eval.directive.SourceDirectives._
 import com.azavea.maml.eval.directive.OpDirectives._
 
 import geotrellis.raster._
+import geotrellis.vector.Extent
 import cats._
 import cats.data.{NonEmptyList => NEL, _}
 import Validated._
@@ -24,12 +25,12 @@ class ResultSpec extends FunSpec with Matchers {
   }
 
   it("Evaluate to desired output (tile)") {
-    TileResult(LazyTile(IntArrayTile(1 to 4 toArray, 2, 2))).as[Int] should be (Invalid(NEL.of(EvalTypeError("int", List("Tile")))))
+    TileResult(LazyTile(IntArrayTile(1 to 4 toArray, 2, 2), Extent(0,0,0,0))).as[Int] should be (Invalid(NEL.of(EvalTypeError("int", List("Tile")))))
     IntResult(1).as[Tile] should matchPattern { case Invalid(_) => }
 
-    TileResult(LazyTile(IntArrayTile(1 to 4 toArray, 2, 2))).as[Tile] should matchPattern { case Valid(_) => }
+    TileResult(LazyTile(IntArrayTile(1 to 4 toArray, 2, 2), Extent(0,0,0,0))).as[Tile] should matchPattern { case Valid(_) => }
 
-    TileResult(LazyTile.MapInt(List(LazyTile(IntArrayTile(1 to 4 toArray, 2, 2))), { i: Int => i + 4 }))
+    TileResult(LazyTile.MapInt(List(LazyTile(IntArrayTile(1 to 4 toArray, 2, 2), Extent(0,0,0,0))), { i: Int => i + 4 }))
       .as[Tile] should matchPattern { case Valid(_) => }
   }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,3 +22,6 @@ addSbtPlugin("io.spray" % "sbt-revolver" % "0.8.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.2.0")
 
 addSbtPlugin("com.47deg"  % "sbt-microsites" % "0.6.1")
+
+addSbtPlugin("com.scalapenos" % "sbt-prompt" % "1.0.2")
+

--- a/shared/src/main/scala/ast/BinaryExpression.scala
+++ b/shared/src/main/scala/ast/BinaryExpression.scala
@@ -38,6 +38,24 @@ case class Masking(children: List[Expression]) extends Operation with BinaryExpr
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
+case class Pow(children: List[Expression]) extends Operation with BinaryExpression {
+  val kindDerivation = { (k1: MamlKind, k2: MamlKind) =>
+    (k1, k2) match {
+      case (MamlKind.Tile, MamlKind.Tile) => MamlKind.Tile
+      case (MamlKind.Tile, MamlKind.Int) => MamlKind.Tile
+      case (MamlKind.Int, MamlKind.Tile) => MamlKind.Tile
+      case (MamlKind.Tile, MamlKind.Double) => MamlKind.Tile
+      case (MamlKind.Double, MamlKind.Tile) => MamlKind.Tile
+      case (MamlKind.Double, MamlKind.Int) => MamlKind.Double
+      case (MamlKind.Int, MamlKind.Double) => MamlKind.Double
+      case (MamlKind.Int, MamlKind.Int) => MamlKind.Double
+      case (MamlKind.Double, MamlKind.Double) => MamlKind.Double
+      case (x1, x2) => throw new InvalidParameterException(s"Expected tile and scalar kinds. Found $x1 and $x2")
+    }
+  }
+  def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
+}
+
 case class Less(children: List[Expression]) extends Operation with BinaryExpression {
   val kindDerivation = BinaryExpression.scalarCompareDerivation _
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)

--- a/shared/src/main/scala/ast/UnaryExpression.scala
+++ b/shared/src/main/scala/ast/UnaryExpression.scala
@@ -71,6 +71,11 @@ case class Atan(children: List[Expression]) extends Operation with UnaryExpressi
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
+case class Round(children: List[Expression]) extends Operation with UnaryExpression {
+  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.tileOrScalar
+  def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
+}
+
 case class Floor(children: List[Expression]) extends Operation with UnaryExpression {
   val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.tileOrScalar
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
@@ -97,17 +102,7 @@ case class SquareRoot(children: List[Expression]) extends Operation with UnaryEx
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
-case class Round(children: List[Expression]) extends Operation with UnaryExpression {
-  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.tileOrScalar
-  def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
-}
-
 case class Abs(children: List[Expression]) extends Operation with UnaryExpression {
-  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.tileOrScalar
-  def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
-}
-
-case class Pow(children: List[Expression]) extends Operation with UnaryExpression {
   val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.tileOrScalar
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }

--- a/spark/src/test/scala/SpatialRDDLocalOperationsSpec.scala
+++ b/spark/src/test/scala/SpatialRDDLocalOperationsSpec.scala
@@ -30,7 +30,7 @@ class SpatialRDDLocalOperationsSpec extends FunSpec
   with Matchers
   with TestEnvironment {
 
-  val interpreter = Interpreter.naive(
+  val interpreter = NaiveInterpreter(List(
     intLiteral,
     dblLiteral,
     RDDSourceDirectives.spatialRDDLiteralDirective,
@@ -38,7 +38,7 @@ class SpatialRDDLocalOperationsSpec extends FunSpec
     RDDOpDirectives.subtractionDirective,
     RDDOpDirectives.multiplicationDirective,
     RDDOpDirectives.divisionDirective
-  )
+  ))
 
   implicit class TypeRefinement(self: Interpreted[Result]) {
     def as[T: ClassTag]: Interpreted[T] = self match {


### PR DESCRIPTION
This PR adds a bunch of `LazyTile` niceties as well as implementations of `Directive`s necessary to evaluate RFML `ToolRun` trees