### PR TITLE
Allow for unbalanced focal trees

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.scalapenos.sbt.prompt.SbtPrompt.autoImport._
 
 promptTheme := com.scalapenos.sbt.prompt.PromptThemes.ScalapenosTheme
 
-val mamlVersion = "0.0.2" + scala.util.Properties.envOrElse("MAML_VERSION_SUFFIX", "")
+val mamlVersion = "0.0.3" + scala.util.Properties.envOrElse("MAML_VERSION_SUFFIX", "")
 
 /** Project configurations */
 lazy val root = project.in(file("."))

--- a/jvm/src/main/scala/eval/tile/LazyTile.scala
+++ b/jvm/src/main/scala/eval/tile/LazyTile.scala
@@ -65,12 +65,14 @@ object LazyTile {
   trait Branch extends LazyTile {
     lazy val cols = {
       val colList = children.map(_.cols).distinct
-      require(colList.length == 1, "Ambiguous column count")
+      // This require block breaks things when there's an imbalance of focal operations on the children
+      //require(colList.length == 1, "Ambiguous column count")
       colList.head
     }
     lazy val rows = {
       val rowList = children.map(_.cols).distinct
-      require(rowList.length == 1, "Ambiguous row count")
+      // This require block breaks things when there's an imbalance of focal operations on the children
+      //require(rowList.length == 1, "Ambiguous row count")
       rowList.head
     }
   }


### PR DESCRIPTION
Remove a guard which was overly protective in that it prevented trees from being constructed which lack balance w/r/t focal operations.