### PR TITLE
LazyTile.rows should return rows

### DIFF
--- a/jvm/src/main/scala/eval/tile/LazyTile.scala
+++ b/jvm/src/main/scala/eval/tile/LazyTile.scala
@@ -17,7 +17,6 @@ import com.typesafe.scalalogging.LazyLogging
 
 import scala.reflect.ClassTag
 
-
 sealed trait LazyTile extends LazyLogging {
   // TODO: We need to find a way to rip RasterExtent out of LazyTile
   //       while still being able to provide it to Masking operations.
@@ -70,7 +69,7 @@ object LazyTile {
       colList.head
     }
     lazy val rows = {
-      val rowList = children.map(_.cols).distinct
+      val rowList = children.map(_.rows).distinct
       // This require block breaks things when there's an imbalance of focal operations on the children
       //require(rowList.length == 1, "Ambiguous row count")
       rowList.head

--- a/jvm/src/test/scala/eval/ResultSpec.scala
+++ b/jvm/src/test/scala/eval/ResultSpec.scala
@@ -33,4 +33,17 @@ class ResultSpec extends FunSpec with Matchers {
     TileResult(LazyTile.MapInt(List(LazyTile(IntArrayTile(1 to 4 toArray, 2, 2), Extent(0,0,0,0))), { i: Int => i + 4 }))
       .as[Tile] should matchPattern { case Valid(_) => }
   }
+
+  it("Evaluate float tile with different cols / rows") {
+    val zero = LazyTile(Raster(FloatArrayTile.fill(0, 52, 36), Extent(0, 0, 4, 4)))
+    val one = LazyTile(Raster(FloatArrayTile.fill(1, 52, 36), Extent(0, 0, 4, 4)))
+    val tr = TileResult(LazyTile.DualCombine(List(zero, one), _ - _, _ - _))
+    val tile = tr.as[Tile].valueOr(r => throw new Exception(r.toString))
+
+    tr.res.cols should be (zero.cols)
+    tr.res.rows should be (zero.rows)
+
+    tr.res.cols should be (tile.cols)
+    tr.res.rows should be (tile.rows)
+  }
 }


### PR DESCRIPTION
Current code has a typo and instead of `rows` `LazyTile.rows` returns `cols.