### PR TITLE
Remove cats-effect dependency and import

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.scalapenos.sbt.prompt.SbtPrompt.autoImport._
 
 promptTheme := com.scalapenos.sbt.prompt.PromptThemes.ScalapenosTheme
 
-val mamlVersion = "0.0.15" + scala.util.Properties.envOrElse("MAML_VERSION_SUFFIX", "")
+val mamlVersion = "0.0.17" + scala.util.Properties.envOrElse("MAML_VERSION_SUFFIX", "")
 
 /** Project configurations */
 lazy val root = project.in(file("."))
@@ -12,8 +12,8 @@ lazy val root = project.in(file("."))
     licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
   ).enablePlugins(ScalaJSPlugin)
 
-val circeVer = "0.10.0-M1"
-val gtVer    = "2.0.0-RC2"
+val circeVer = "0.10.0"
+val gtVer    = "2.0.0"
 
 lazy val maml = crossProject.in(file("."))
   .settings(publishSettings:_*)

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,6 @@ lazy val maml = crossProject.in(file("."))
       "org.scalacheck"             %% "scalacheck"           % "1.13.4" % "test",
       "org.scalatest"              %% "scalatest"            % "3.0.1"  % "test",
       "com.typesafe.scala-logging" %% "scala-logging"        % "3.9.0",
-      "org.typelevel"              %% "cats-effect"          % "0.10.1",
       "io.circe"                   %% "circe-core"           % circeVer,
       "io.circe"                   %% "circe-generic"        % circeVer,
       "io.circe"                   %% "circe-generic-extras" % circeVer,

--- a/shared/src/main/scala/ast/Source.scala
+++ b/shared/src/main/scala/ast/Source.scala
@@ -7,7 +7,6 @@ import cats.data.{NonEmptyList => NEL, _}
 import Validated._
 import io.circe.Json
 import io.circe.generic.JsonCodec
-import cats.effect.IO
 
 import java.lang.IllegalArgumentException
 


### PR DESCRIPTION
Overview
----

This PR removes `cats-effect` as a dependency and removes an unused import of `cats.effect.IO`. The reason for it is that cats-effect < 1 is binary incompatible with cats-effect > 1, so anything transitively depending on `maml` can't upgrade.

Notes
-----

I at least think this is an issue -- I'm not sure why unused code deep in dependencies would affect anything, but this is I think the only place that a dependency on `cats-effect` 0.10 is coming in to Raster Foundry's [`backsplash` subproject](https://github.com/raster-foundry/raster-foundry/blob/develop/app-backend/build.sbt#L441-L453).

Testing
-----

- `rg cats.effect`
- confirm it was never used anywhere