### PR TITLE
Add first class multiband rasters

### DIFF
--- a/jvm/src/main/scala/dsl/tile/LazyMultibandRasterOperations.scala
+++ b/jvm/src/main/scala/dsl/tile/LazyMultibandRasterOperations.scala
@@ -1,0 +1,429 @@
+package com.azavea.maml.dsl.tile
+
+import com.azavea.maml.eval.tile._
+
+import geotrellis.raster._
+import geotrellis.raster.render.BreakMap
+import geotrellis.raster.mapalgebra.local._
+
+
+trait LazyMultibandRasterOperations {
+  val self: LazyMultibandRaster
+
+  /** Arithmetic Operations*/
+  def +(other: LazyMultibandRaster): LazyMultibandRaster =
+    self.dualCombine(other, Add.combine, Add.combine)
+  def +(other: Int): LazyMultibandRaster =
+    self.dualMap(
+      { Add.combine(_, other) },
+      { Add.combine(_, other) }
+    )
+  def +:(other: Int): LazyMultibandRaster =
+    self.dualMap(
+      { Add.combine(other, _) },
+      { Add.combine(other, _) }
+    )
+  def +(other: Double): LazyMultibandRaster =
+    self.dualMap(
+      { Add.combine(_, d2i(other)) },
+      { Add.combine(_, other) }
+    )
+  def +:(other: Double): LazyMultibandRaster =
+    self.dualMap(
+      { Add.combine(d2i(other), _) },
+      { Add.combine(other, _) }
+    )
+
+  def -(other: LazyMultibandRaster): LazyMultibandRaster =
+    self.dualCombine(other, Subtract.combine, Subtract.combine)
+  def -(other: Int): LazyMultibandRaster =
+    self.dualMap(
+      { Subtract.combine(_, other) },
+      { Subtract.combine(_, i2d(other)) }
+    )
+  def -:(other: Int): LazyMultibandRaster =
+    self.dualMap(
+      { Subtract.combine(other, _) },
+      { Subtract.combine(i2d(other), _) }
+    )
+  def -(other: Double): LazyMultibandRaster =
+    self.dualMap(
+      { Subtract.combine(_, d2i(other)) },
+      { Subtract.combine(_, other) }
+    )
+  def -:(other: Double): LazyMultibandRaster =
+    self.dualMap(
+      { Subtract.combine(d2i(other), _) },
+      { Subtract.combine(other, _) }
+    )
+
+  def *(other: LazyMultibandRaster): LazyMultibandRaster =
+    self.dualCombine(other, Multiply.combine, Multiply.combine)
+  def *(other: Int): LazyMultibandRaster =
+    self.dualMap(
+      { Multiply.combine(_, other) },
+      { Multiply.combine(_, i2d(other)) }
+    )
+  def *:(other: Int): LazyMultibandRaster =
+    self.dualMap(
+      { Multiply.combine(other, _) },
+      { Multiply.combine(i2d(other), _) }
+    )
+  def *(other: Double): LazyMultibandRaster =
+    self.dualMap(
+      { Multiply.combine(_, d2i(other)) },
+      { Multiply.combine(_, other) }
+    )
+  def *:(other: Double): LazyMultibandRaster =
+    self.dualMap(
+      { Multiply.combine(d2i(other), _) },
+      { Multiply.combine(other, _) }
+    )
+
+  def /(other: LazyMultibandRaster): LazyMultibandRaster =
+    self.dualCombine(other, Divide.combine, Divide.combine)
+  def /(other: Int): LazyMultibandRaster =
+    self.dualMap(
+      { Divide.combine(_, other) },
+      { Divide.combine(_, i2d(other)) }
+    )
+  def /:(other: Int): LazyMultibandRaster =
+    self.dualMap(
+      { Divide.combine(other, _) },
+      { Divide.combine(i2d(other), _) }
+    )
+  def /(other: Double): LazyMultibandRaster =
+    self.dualMap(
+      { Divide.combine(_, d2i(other)) },
+      { Divide.combine(_, other) }
+    )
+  def /:(other: Double): LazyMultibandRaster =
+    self.dualMap(
+      { Divide.combine(d2i(other), _) },
+      { Divide.combine(other, _) }
+    )
+
+  def **(other: LazyMultibandRaster): LazyMultibandRaster =
+    self.dualCombine(other, Pow.combine, Pow.combine)
+  def **(other: Int): LazyMultibandRaster =
+    self.dualMap(
+      { Pow.combine(_, other) },
+      { Pow.combine(_, i2d(other)) }
+    )
+  def **:(other: Int): LazyMultibandRaster =
+    self.dualMap(
+      { Pow.combine(other, _) },
+      { Pow.combine(i2d(other), _) }
+    )
+  def **(other: Double): LazyMultibandRaster =
+    self.dualMap(
+      { Pow.combine(_, d2i(other)) },
+      { Pow.combine(_, other) }
+    )
+  def **:(other: Double): LazyMultibandRaster =
+    self.dualMap(
+      { Pow.combine(d2i(other), _) },
+      { Pow.combine(other, _) }
+    )
+
+
+  def logE: LazyMultibandRaster =
+    self.dualMap(
+      { z: Int => if(isNoData(z)) z else d2i(math.log(i2d(z))) },
+      { z => if(isNoData(z)) z else math.log(z) }
+    )
+
+  def log10: LazyMultibandRaster =
+    self.dualMap(
+      { z: Int => if(isNoData(z)) z else d2i(math.log10(i2d(z))) },
+      { z => if(isNoData(z)) z else math.log10(z) }
+    )
+
+  def sqrt: LazyMultibandRaster =
+    self.dualMap(
+      { z: Int => if(isNoData(z)) z else d2i(math.sqrt(i2d(z))) },
+      { z => if(isNoData(z)) z else math.sqrt(z) }
+    )
+
+  def abs: LazyMultibandRaster =
+    self.dualMap(
+      { z: Int => if(isNoData(z)) z else math.abs(z) },
+      { z => if(isNoData(z)) z else math.abs(z) }
+    )
+
+  def isDefined: LazyMultibandRaster =
+    self.dualMap(
+      { z: Int => if (isData(z)) 1 else 0 },
+      { z => if (isData(z)) 1.0 else 0.0 }
+    )
+
+  def isUndefined: LazyMultibandRaster =
+    self.dualMap(
+      { z: Int => if (isNoData(z)) 1 else 0 },
+      { z => if (isNoData(z)) 1.0 else 0.0 }
+    )
+
+  def pow(i: Int): LazyMultibandRaster =
+    self.dualMap(
+      { z: Int => if (isNoData(z)) 1 else 0 },
+      { z => if (isNoData(z)) 1.0 else 0.0 }
+    )
+
+  def pow(d: Double): LazyMultibandRaster =
+    self.dualMap(
+      { z: Int => if (isNoData(z)) 1 else 0 },
+      { z => if (isNoData(z)) 1.0 else 0.0 }
+    )
+
+  def changeSign: LazyMultibandRaster =
+    self.dualMap(
+      { z: Int => if (isNoData(z)) z else z * -1 },
+      { z => if (isNoData(z)) z else z * - 1 }
+    )
+
+  /** Numeric Comparisons */
+  def <(other: LazyMultibandRaster): LazyMultibandRaster =
+    self.dualCombine(other,
+      { (i1: Int, i2: Int) => if (Less.compare(i1, i2)) 1 else 0 },
+      { (d1: Double, d2: Double) => if (Less.compare(d1, d2)) 1.0 else 0.0 }
+    )
+  def <(other: Int): LazyMultibandRaster =
+    self.dualMap(
+      { (i: Int) => if (Less.compare(i, other.toInt)) 1 else 0 },
+      { (d: Double) => if (Less.compare(d, other)) 1.0 else 0.0 }
+    )
+  def <(other: Double): LazyMultibandRaster =
+    self.dualMap(
+      { (i: Int) => if (Less.compare(i, other.toInt)) 1 else 0 },
+      { (d: Double) => if (Less.compare(d, other)) 1.0 else 0.0 }
+    )
+
+  def <=(other: LazyMultibandRaster): LazyMultibandRaster =
+    self.dualCombine(other,
+      { (i1: Int, i2: Int) => if (LessOrEqual.compare(i1, i2)) 1 else 0 },
+      { (d1: Double, d2: Double) => if (LessOrEqual.compare(d1, d2)) 1.0 else 0.0 }
+    )
+  def <=(other: Int): LazyMultibandRaster =
+    self.dualMap(
+      { (i: Int) => if (LessOrEqual.compare(i, other.toInt)) 1 else 0 },
+      { (d: Double) => if (LessOrEqual.compare(d, other)) 1.0 else 0.0 }
+    )
+  def <=(other: Double): LazyMultibandRaster =
+    self.dualMap(
+      { (i: Int) => if (LessOrEqual.compare(i, other.toInt)) 1 else 0 },
+      { (d: Double) => if (LessOrEqual.compare(d, other)) 1.0 else 0.0 }
+    )
+
+  def ===(other: LazyMultibandRaster): LazyMultibandRaster =
+    self.dualCombine(other,
+      { (i1: Int, i2: Int) => if (Equal.compare(i1, i2)) 1 else 0 },
+      { (d1: Double, d2: Double) => if (Equal.compare(d1, d2)) 1.0 else 0.0 }
+    )
+  def ===(other: Int): LazyMultibandRaster =
+    self.dualMap(
+      { (i: Int) => if (Equal.compare(i, other.toInt)) 1 else 0 },
+      { (d: Double) => if (Equal.compare(d, other)) 1.0 else 0.0 }
+    )
+  def ===(other: Double): LazyMultibandRaster =
+    self.dualMap(
+      { (i: Int) => if (Equal.compare(i, other.toInt)) 1 else 0 },
+      { (d: Double) => if (Equal.compare(d, other)) 1.0 else 0.0 }
+    )
+
+  def !==(other: LazyMultibandRaster): LazyMultibandRaster =
+    self.dualCombine(other,
+      { (i1: Int, i2: Int) => if (Unequal.compare(i1, i2)) 1 else 0 },
+      { (d1: Double, d2: Double) => if (Unequal.compare(d1, d2)) 1.0 else 0.0 }
+    )
+  def !==(other: Int): LazyMultibandRaster =
+    self.dualMap(
+      { (i: Int) => if (Unequal.compare(i, other.toInt)) 1 else 0 },
+      { (d: Double) => if (Unequal.compare(d, other)) 1.0 else 0.0 }
+    )
+  def !==(other: Double): LazyMultibandRaster =
+    self.dualMap(
+      { (i: Int) => if (Unequal.compare(i, other.toInt)) 1 else 0 },
+      { (d: Double) => if (Unequal.compare(d, other)) 1.0 else 0.0 }
+    )
+
+  def >=(other: LazyMultibandRaster): LazyMultibandRaster =
+    self.dualCombine(other,
+      { (i1: Int, i2: Int) => if (GreaterOrEqual.compare(i1, i2)) 1 else 0 },
+      { (d1: Double, d2: Double) => if (GreaterOrEqual.compare(d1, d2)) 1.0 else 0.0 }
+    )
+  def >=(other: Int): LazyMultibandRaster =
+    self.dualMap(
+      { (i: Int) => if (GreaterOrEqual.compare(i, other.toInt)) 1 else 0 },
+      { (d: Double) => if (GreaterOrEqual.compare(d, other)) 1.0 else 0.0 }
+    )
+  def >=(other: Double): LazyMultibandRaster =
+    self.dualMap(
+      { (i: Int) => if (GreaterOrEqual.compare(i, other.toInt)) 1 else 0 },
+      { (d: Double) => if (GreaterOrEqual.compare(d, other)) 1.0 else 0.0 }
+    )
+
+  def >(other: LazyMultibandRaster): LazyMultibandRaster =
+    self.dualCombine(other,
+      { (i1: Int, i2: Int) => if (Greater.compare(i1, i2)) 1 else 0 },
+      { (d1: Double, d2: Double) => if (Greater.compare(d1, d2)) 1.0 else 0.0 }
+    )
+  def >(other: Int): LazyMultibandRaster =
+    self.dualMap(
+      { (i: Int) => if (Greater.compare(i, other.toInt)) 1 else 0 },
+      { (d: Double) => if (Greater.compare(d, other)) 1.0 else 0.0 }
+    )
+  def >(other: Double): LazyMultibandRaster =
+    self.dualMap(
+      { (i: Int) => if (Greater.compare(i, other.toInt)) 1 else 0 },
+      { (d: Double) => if (Greater.compare(d, other)) 1.0 else 0.0 }
+    )
+
+  /** Trigonometric Operations */
+  def sin: LazyMultibandRaster =
+    self.dualMap(
+    { z: Int => if(isNoData(z)) z else d2i(math.sin(z)) },
+    { z => if(isNoData(z)) z else math.sin(z) }
+  )
+  def cos: LazyMultibandRaster =
+    self.dualMap(
+    { z: Int => if(isNoData(z)) z else d2i(math.cos(z)) },
+    { z => if(isNoData(z)) z else math.cos(z) }
+  )
+  def tan: LazyMultibandRaster =
+    self.dualMap(
+    { z: Int => if(isNoData(z)) z else d2i(math.tan(z)) },
+    { z => if(isNoData(z)) z else math.tan(z) }
+  )
+
+  def sinh: LazyMultibandRaster =
+    self.dualMap(
+    { z: Int => if(isNoData(z)) z else d2i(math.sinh(z)) },
+    { z => if(isNoData(z)) z else math.sinh(z) }
+  )
+  def cosh: LazyMultibandRaster =
+    self.dualMap(
+    { z: Int => if(isNoData(z)) z else d2i(math.cosh(z)) },
+    { z => if(isNoData(z)) z else math.cosh(z) }
+  )
+  def tanh: LazyMultibandRaster =
+    self.dualMap(
+    { z: Int => if(isNoData(z)) z else d2i(math.tanh(z)) },
+    { z => if(isNoData(z)) z else math.tanh(z) }
+  )
+
+  def asin: LazyMultibandRaster =
+    self.dualMap(
+    { z: Int => if(isNoData(z)) z else d2i(math.asin(z)) },
+    { z => if(isNoData(z)) z else math.asin(z) }
+  )
+  def acos: LazyMultibandRaster =
+    self.dualMap(
+    { z: Int => if(isNoData(z)) z else d2i(math.acos(z)) },
+    { z => if(isNoData(z)) z else math.acos(z) }
+  )
+  def atan: LazyMultibandRaster =
+    self.dualMap(
+    { z: Int => if(isNoData(z)) z else d2i(math.atan(z)) },
+    { z => if(isNoData(z)) z else math.atan(z) }
+  )
+
+  def atan2(other: LazyMultibandRaster) =
+    self.dualCombine(other,
+      { (z1, z2) => d2i(math.atan2(i2d(z1), i2d(z2))) },
+      { (z1, z2) => math.atan2(z1, z2) }
+    )
+  def atan2(other: Int): LazyMultibandRaster =
+    self.dualMap(
+      { i: Int => d2i(math.atan2(i, other)) },
+      { math.atan2(_, other) }
+    )
+  def atan2(other: Double): LazyMultibandRaster =
+    self.dualMap(
+      { i: Int => d2i(math.atan2(i, other)) },
+      { math.atan2(_, other) }
+    )
+
+  /** Rounding Operations */
+  def round: LazyMultibandRaster =
+    self.dualMap(
+      identity,
+      { z => if(isNoData(z)) z else math.round(z) }
+    )
+
+  def floor: LazyMultibandRaster =
+    self.dualMap(
+      identity,
+      { z => if(isNoData(z)) z else math.floor(z) }
+    )
+
+  def ceil: LazyMultibandRaster =
+    self.dualMap(
+      identity,
+      { z => if(isNoData(z)) z else math.ceil(z) }
+    )
+
+  /** Logical Operations */
+  // TODO: Look into GT implementations for logical operations...
+  //       The handling of nodata vs 0 vs false is not obvious
+  def &&(other: LazyMultibandRaster): LazyMultibandRaster =
+    self.dualCombine(other, And.combine, And.combine)
+  def &&(other: Int): LazyMultibandRaster =
+    self.dualMap(
+      { And.combine(_, other) },
+      { And.combine(_, other) }
+    )
+  def &&:(other: Int): LazyMultibandRaster =
+    self.dualMap(
+      { And.combine(_, other) },
+      { And.combine(_, other) }
+    )
+  def &&(other: Double): LazyMultibandRaster =
+    self.dualMap(
+      { And.combine(_, d2i(other)) },
+      { And.combine(_, other) }
+    )
+  def &&:(other: Double): LazyMultibandRaster =
+    self.dualMap(
+      { And.combine(_, d2i(other)) },
+      { And.combine(_, other) }
+    )
+
+  def ||(other: LazyMultibandRaster): LazyMultibandRaster =
+    self.dualCombine(other, Or.combine, Or.combine)
+  def ||(other: Int): LazyMultibandRaster =
+    self.dualMap( { Or.combine(_, other) }, { Or.combine(_, other) })
+  def ||:(other: Int): LazyMultibandRaster =
+    self.dualMap( { Or.combine(_, other) }, { Or.combine(_, other) })
+  def ||(other: Double): LazyMultibandRaster =
+    self.dualMap( { Or.combine(_, d2i(other)) }, { Or.combine(_, other) })
+  def ||:(other: Double): LazyMultibandRaster =
+    self.dualMap( { Or.combine(_, d2i(other)) }, { Or.combine(_, other) })
+
+  def xor(other: LazyMultibandRaster): LazyMultibandRaster =
+    self.dualCombine(other, Xor.combine, Xor.combine)
+  def xor(other: Int): LazyMultibandRaster =
+    self.dualMap(
+      { Xor.combine(_, other) },
+      { Xor.combine(_, other) }
+    )
+  def xor(other: Double): LazyMultibandRaster =
+    self.dualMap(
+      { Xor.combine(_, d2i(other)) },
+      { Xor.combine(_, other) }
+    )
+
+  def not: LazyMultibandRaster =
+    self.dualMap(
+      { z => if (isNoData(z)) z else if (z == 0) 1 else 0 },
+      { z => if (isNoData(z)) z else if (z == 0.0) 1.0 else 0.0 }
+    )
+
+  /** Tile specific methods */
+  def classify(breaks: BreakMap[Double, Int]) =
+    self.dualMap(
+      { i => breaks(i2d(i)) },
+      { d => i2d(breaks(d)) }
+    )
+
+}
+

--- a/jvm/src/main/scala/dsl/tile/package.scala
+++ b/jvm/src/main/scala/dsl/tile/package.scala
@@ -5,4 +5,5 @@ import com.azavea.maml.eval.tile._
 
 package object tile {
   implicit class LazyTileExtensions(val self: LazyTile) extends LazyTileOperations
+  implicit class LazyMultibandRasterExtensions(val self: LazyMultibandRaster) extends LazyMultibandRasterOperations
 }

--- a/jvm/src/main/scala/eval/BufferingInterpreter.scala
+++ b/jvm/src/main/scala/eval/BufferingInterpreter.scala
@@ -111,8 +111,8 @@ object BufferingInterpreter {
       GridBounds(n.extent, n.extent, scope.tileSize - 1 + scope.buffer * 2 + n.extent, scope.tileSize - 1 + scope.buffer * 2 + n.extent)
 
     childResults.head match {
-      case TileResult(lzTile) =>
-        Valid(TileResult(LazyTile.Focal(List(lzTile), n, Some(gridbounds), focal.Max.apply _)))
+      case ImageResult(lzTile) =>
+        Valid(ImageResult(lzTile.focal(n, Some(gridbounds), focal.Max.apply _)))
     }
   }
 
@@ -122,8 +122,8 @@ object BufferingInterpreter {
       GridBounds(n.extent, n.extent, scope.tileSize - 1 + scope.buffer * 2 + n.extent, scope.tileSize - 1 + scope.buffer * 2 + n.extent)
 
     childResults.head match {
-      case TileResult(lzTile) =>
-        Valid(TileResult(LazyTile.Focal(List(lzTile), n, Some(gridbounds), focal.Min.apply _)))
+      case ImageResult(lzTile) =>
+        Valid(ImageResult(lzTile.focal(n, Some(gridbounds), focal.Min.apply _)))
     }
   }
 
@@ -133,8 +133,8 @@ object BufferingInterpreter {
       GridBounds(n.extent, n.extent, scope.tileSize - 1 + scope.buffer * 2 + n.extent, scope.tileSize - 1 + scope.buffer * 2 + n.extent)
 
     childResults.head match {
-      case TileResult(lzTile) =>
-        Valid(TileResult(LazyTile.Focal(List(lzTile), n, Some(gridbounds), focal.Mean.apply _)))
+      case ImageResult(lzTile) =>
+        Valid(ImageResult(lzTile.focal(n, Some(gridbounds), focal.Mean.apply _)))
     }
   }
 
@@ -144,8 +144,8 @@ object BufferingInterpreter {
       GridBounds(n.extent, n.extent, scope.tileSize - 1 + scope.buffer * 2 + n.extent, scope.tileSize - 1 + scope.buffer * 2 + n.extent)
 
     childResults.head match {
-      case TileResult(lzTile) =>
-        Valid(TileResult(LazyTile.Focal(List(lzTile), n, Some(gridbounds), focal.Median.apply _)))
+      case ImageResult(lzTile) =>
+        Valid(ImageResult(lzTile.focal(n, Some(gridbounds), focal.Median.apply _)))
     }
   }
 
@@ -155,8 +155,8 @@ object BufferingInterpreter {
       GridBounds(n.extent, n.extent, scope.tileSize - 1 + scope.buffer * 2 + n.extent, scope.tileSize - 1 + scope.buffer * 2 + n.extent)
 
     childResults.head match {
-      case TileResult(lzTile) =>
-        Valid(TileResult(LazyTile.Focal(List(lzTile), n, Some(gridbounds), focal.Mode.apply _)))
+      case ImageResult(lzTile) =>
+        Valid(ImageResult(lzTile.focal(n, Some(gridbounds), focal.Mode.apply _)))
     }
   }
 
@@ -166,8 +166,8 @@ object BufferingInterpreter {
       GridBounds(n.extent, n.extent, scope.tileSize - 1 + scope.buffer * 2 + n.extent, scope.tileSize - 1 + scope.buffer * 2 + n.extent)
 
     childResults.head match {
-      case TileResult(lzTile) =>
-        Valid(TileResult(LazyTile.Focal(List(lzTile), n, Some(gridbounds), focal.Sum.apply _)))
+      case ImageResult(lzTile) =>
+        Valid(ImageResult(lzTile.focal(n, Some(gridbounds), focal.Sum.apply _)))
     }
   }
 
@@ -177,8 +177,8 @@ object BufferingInterpreter {
       GridBounds(n.extent, n.extent, scope.tileSize - 1 + scope.buffer * 2 + n.extent, scope.tileSize - 1 + scope.buffer * 2 + n.extent)
 
     childResults.head match {
-      case TileResult(lzTile) =>
-        Valid(TileResult(LazyTile.Focal(List(lzTile), n, Some(gridbounds), focal.StandardDeviation.apply _)))
+      case ImageResult(lzTile) =>
+        Valid(ImageResult(lzTile.focal(n, Some(gridbounds), focal.StandardDeviation.apply _)))
     }
   }
 }

--- a/jvm/src/main/scala/eval/Result.scala
+++ b/jvm/src/main/scala/eval/Result.scala
@@ -5,7 +5,8 @@ import com.azavea.maml.error._
 import com.azavea.maml.eval._
 import com.azavea.maml.eval.tile._
 
-import geotrellis.raster.Tile
+import geotrellis.raster.MultibandTile
+import geotrellis.raster.io.geotiff.MultibandGeoTiff
 import geotrellis.vector.Geometry
 import cats.data.{NonEmptyList => NEL, _}
 import Validated._
@@ -55,17 +56,19 @@ case class GeomResult(res: Geometry) extends Result {
   def kind: MamlKind = MamlKind.Geom
 }
 
-case class TileResult(res: LazyTile) extends Result {
+case class ImageResult(res: LazyMultibandRaster) extends Result {
   def as[T](implicit ct: ClassTag[T]): Interpreted[T] = {
     val cls = ct.runtimeClass
-    if (classOf[Tile] isAssignableFrom cls)
+    if (classOf[MultibandTile] isAssignableFrom cls)
       Valid(res.evaluateDouble.asInstanceOf[T])
-    else if (classOf[LazyTile] isAssignableFrom cls)
+    else if (classOf[MultibandGeoTiff] isAssignableFrom cls)
+      Valid(res.evaluateDouble.asInstanceOf[T])
+    else if (classOf[LazyMultibandRaster] isAssignableFrom cls)
       Valid(res.asInstanceOf[T])
     else
-      Invalid(NEL.of(DivergingTypes(cls.getName, List("Tile"))))
+      Invalid(NEL.of(DivergingTypes(cls.getName, List("img"))))
   }
-  def kind: MamlKind = MamlKind.Tile
+  def kind: MamlKind = MamlKind.Image
 }
 
 case class BoolResult(res: Boolean) extends Result {

--- a/jvm/src/main/scala/eval/directive/FocalDirectives.scala
+++ b/jvm/src/main/scala/eval/directive/FocalDirectives.scala
@@ -17,64 +17,64 @@ import Validated._
 object FocalDirectives {
   val max = Directive { case (fm@FocalMax(_, neighborhood), childResults) =>
     childResults
-      .map({ _.as[LazyTile] })
+      .map({ _.as[LazyMultibandRaster] })
       .toList.sequence
       .map({ lt =>
-        TileResult(LazyTile.Focal(lt, NeighborhoodConversion(neighborhood), None, focal.Max.apply _))
+        ImageResult(lt.head.focal(NeighborhoodConversion(neighborhood), None, focal.Max.apply _))
       })
   }
 
   val min = Directive { case (fm@FocalMin(_, neighborhood), childResults) =>
     childResults
-      .map({ _.as[LazyTile] })
+      .map({ _.as[LazyMultibandRaster] })
       .toList.sequence
       .map({ lt =>
-        TileResult(LazyTile.Focal(lt, NeighborhoodConversion(neighborhood), None, focal.Min.apply _))
+        ImageResult(lt.head.focal(NeighborhoodConversion(neighborhood), None, focal.Min.apply _))
       })
   }
 
   val mean = Directive { case (fm@FocalMean(_, neighborhood), childResults) =>
     childResults
-      .map({ _.as[LazyTile] })
+      .map({ _.as[LazyMultibandRaster] })
       .toList.sequence
       .map({ lt =>
-        TileResult(LazyTile.Focal(lt, NeighborhoodConversion(neighborhood), None, focal.Mean.apply _))
+        ImageResult(lt.head.focal(NeighborhoodConversion(neighborhood), None, focal.Mean.apply _))
       })
   }
 
   val median = Directive { case (fm@FocalMedian(_, neighborhood), childResults) =>
     childResults
-      .map({ _.as[LazyTile] })
+      .map({ _.as[LazyMultibandRaster] })
       .toList.sequence
       .map({ lt =>
-        TileResult(LazyTile.Focal(lt, NeighborhoodConversion(neighborhood), None, focal.Median.apply _))
+        ImageResult(lt.head.focal(NeighborhoodConversion(neighborhood), None, focal.Median.apply _))
       })
   }
 
   val mode = Directive { case (fm@FocalMode(_, neighborhood), childResults) =>
     childResults
-      .map({ _.as[LazyTile] })
+      .map({ _.as[LazyMultibandRaster] })
       .toList.sequence
       .map({ lt =>
-        TileResult(LazyTile.Focal(lt, NeighborhoodConversion(neighborhood), None, focal.Mode.apply _))
+        ImageResult(lt.head.focal(NeighborhoodConversion(neighborhood), None, focal.Mode.apply _))
       })
   }
 
   val sum = Directive { case (fm@FocalSum(_, neighborhood), childResults) =>
     childResults
-      .map({ _.as[LazyTile] })
+      .map({ _.as[LazyMultibandRaster] })
       .toList.sequence
       .map({ lt =>
-        TileResult(LazyTile.Focal(lt, NeighborhoodConversion(neighborhood), None, focal.Sum.apply _))
+        ImageResult(lt.head.focal(NeighborhoodConversion(neighborhood), None, focal.Sum.apply _))
       })
   }
 
   val standardDeviation = Directive { case (fm@FocalStdDev(_, neighborhood), childResults) =>
     childResults
-      .map({ _.as[LazyTile] })
+      .map({ _.as[LazyMultibandRaster] })
       .toList.sequence
       .map({ lt =>
-        TileResult(LazyTile.Focal(lt, NeighborhoodConversion(neighborhood), None, focal.StandardDeviation.apply _))
+        ImageResult(lt.head.focal(NeighborhoodConversion(neighborhood), None, focal.StandardDeviation.apply _))
       })
   }
 }

--- a/jvm/src/main/scala/eval/directive/SourceDirectives.scala
+++ b/jvm/src/main/scala/eval/directive/SourceDirectives.scala
@@ -5,11 +5,11 @@ import com.azavea.maml.eval._
 import com.azavea.maml.eval.tile._
 import com.azavea.maml.ast._
 
-import geotrellis.vector.io._
-import geotrellis.vector.Geometry
-import geotrellis.raster.{Raster, Tile}
 import io.circe._
 import io.circe.parser._
+import geotrellis.vector.io._
+import geotrellis.vector.Geometry
+import geotrellis.raster._
 import cats.data.{NonEmptyList => NEL, _}
 import Validated._
 
@@ -23,9 +23,9 @@ object SourceDirectives {
   val boolLiteral = Directive { case (BoolLit(bool), _) => Valid(BoolResult(bool)) }
 
   val rasterLiteral = Directive {
-    case (RasterLit(r), _) if r.isInstanceOf[Raster[_]] =>
-      val raster = r.asInstanceOf[Raster[Tile]]
-      Valid(TileResult(LazyTile(raster.tile, raster.extent)))
+    case (RasterLit(r), _) if r.isInstanceOf[Raster[MultibandTile]] =>
+      val mbRaster = r.asInstanceOf[Raster[MultibandTile]]
+      Valid(ImageResult(LazyMultibandRaster(mbRaster)))
     case (rl@RasterLit(r), _) =>
       Invalid(NEL.of(NonEvaluableNode(rl, Some("Unable to treat raster literal contents as type Raster"))))
   }

--- a/jvm/src/main/scala/eval/directive/UnaryDirectives.scala
+++ b/jvm/src/main/scala/eval/directive/UnaryDirectives.scala
@@ -21,23 +21,23 @@ object UnaryDirectives {
   private def not[A](f: A => Boolean): A => Boolean = !f(_)
 
   private def tileOrScalarResult(
-    t: LazyTile => LazyTile,
+    t: LazyMultibandRaster => LazyMultibandRaster,
     i: Int => Double,
     d: Double => Double,
     arg: Result
   ): Result = arg match {
-    case TileResult(lt) => TileResult(t(lt))
+    case ImageResult(lt) => ImageResult(t(lt))
     case IntResult(int) => DoubleResult(i(int))
     case DoubleResult(dbl) => DoubleResult(d(dbl))
   }
 
   private def tileOrBoolResult(
-    t: LazyTile => LazyTile,
+    t: LazyMultibandRaster => LazyMultibandRaster,
     i: Int => Boolean,
     d: Double => Boolean,
     arg: Result
   ): Result = arg match {
-    case TileResult(lt) => TileResult(t(lt))
+    case ImageResult(lt) => ImageResult(t(lt))
     case IntResult(int) => BoolResult(i(int))
     case DoubleResult(dbl) => BoolResult(d(dbl))
   }
@@ -147,7 +147,7 @@ object UnaryDirectives {
   /** Tile-specific Operations */
   val classification = Directive { case (classify@Classification(_, classMap), childResults) =>
     childResults.head match {
-      case TileResult(lzTile) => Valid(TileResult(lzTile.classify(BreakMap(classMap.classifications))))
+      case ImageResult(lzTile) => Valid(ImageResult(lzTile.classify(BreakMap(classMap.classifications))))
       case _ => Invalid(NEL.of(NonEvaluableNode(classify, Some("Classification node requires lazytile argument"))))
     }
   }

--- a/jvm/src/main/scala/eval/tile/LazyMultibandRaster.scala
+++ b/jvm/src/main/scala/eval/tile/LazyMultibandRaster.scala
@@ -1,0 +1,68 @@
+package com.azavea.maml.eval.tile
+
+import com.azavea.maml.eval._
+
+import geotrellis.raster._
+import geotrellis.raster.mapalgebra.local._
+import geotrellis.raster.mapalgebra.focal.{ Neighborhood, TargetCell }
+import geotrellis.raster.render._
+import geotrellis.vector.{ Extent, MultiPolygon, Point }
+import cats._
+import cats.data._
+import cats.data.Validated._
+import cats.data.{NonEmptyList => NEL, _}
+import cats.implicits._
+import spire.syntax.cfor._
+
+
+case class LazyMultibandRaster(val bands: Map[String, LazyTile]) {
+  def select(labels: Seq[String]) = {
+    val selected = bands.filterKeys { labels contains _ }
+    val keyOrder = labels.zipWithIndex.toMap
+    val reordered = bands.toArray.sortWith { case ((k1, _), (k2, _)) =>
+      keyOrder(k1) < keyOrder(k2)
+    }.toMap
+    LazyMultibandRaster(reordered)
+  }
+
+  def evaluateAs(ct: CellType): MultibandTile =
+    MultibandTile(bands.values.map(_.evaluateAs(ct)))
+
+  def evaluate: MultibandTile =
+    evaluateAs(IntConstantNoDataCellType)
+
+  def evaluateDouble: MultibandTile =
+    evaluateAs(DoubleConstantNoDataCellType)
+
+  def dualCombine(
+    other: LazyMultibandRaster,
+    f: (Int, Int) => Int,
+    g: (Double, Double) => Double
+  ): LazyMultibandRaster = {
+    val newBands = bands.keys.map { key =>
+      (key -> LazyTile.DualCombine(List(bands(key), other.bands(key)), f, g))
+    }.toMap
+    LazyMultibandRaster(newBands)
+  }
+
+  def dualMap(f: Int => Int, g: Double => Double): LazyMultibandRaster =
+    LazyMultibandRaster(bands.mapValues({ lt => LazyTile.DualMap(List(lt), f, g) }))
+
+  def focal(
+    neighborhood: Neighborhood,
+    gridbounds: Option[GridBounds],
+    focalFn: (Tile, Neighborhood, Option[GridBounds], TargetCell) => Tile
+  ): LazyMultibandRaster = {
+    val lztiles = bands.mapValues({ lt => LazyTile.Focal(List(lt), neighborhood, gridbounds, focalFn) })
+    LazyMultibandRaster(lztiles)
+  }
+}
+
+object LazyMultibandRaster {
+  def apply(lazytiles: Seq[LazyTile]): LazyMultibandRaster = {
+    val defaultLabels = lazytiles.zipWithIndex.map(lt => lt._2.toString -> lt._1).toMap
+    LazyMultibandRaster(defaultLabels)
+  }
+  def apply(mbRaster: Raster[MultibandTile]): LazyMultibandRaster =
+    LazyMultibandRaster(mbRaster.tile.bands.map(LazyTile(_, mbRaster.extent)))
+}

--- a/jvm/src/main/scala/eval/tile/LazyTile.scala
+++ b/jvm/src/main/scala/eval/tile/LazyTile.scala
@@ -13,11 +13,11 @@ import cats.data.Validated._
 import cats.data.{NonEmptyList => NEL, _}
 import cats.implicits._
 import spire.syntax.cfor._
-import com.typesafe.scalalogging.LazyLogging
 
 import scala.reflect.ClassTag
 
-sealed trait LazyTile extends LazyLogging {
+
+sealed trait LazyTile {
   // TODO: We need to find a way to rip RasterExtent out of LazyTile
   //       while still being able to provide it to Masking operations.
   //       Is this a use case for futo or paramorphisms?

--- a/jvm/src/test/scala/eval/EvaluationSpec.scala
+++ b/jvm/src/test/scala/eval/EvaluationSpec.scala
@@ -23,7 +23,7 @@ import scala.reflect._
 
 class EvaluationSpec extends FunSpec with Matchers with ExpressionTreeCodec {
 
-  implicit def tileIsTileLiteral(tile: Tile): Expression = RasterLit(Raster(tile, Extent(0, 0, 0, 0)))
+  implicit def tileIsTileLiteral(tile: Tile): Expression = RasterLit(Raster(MultibandTile(tile), Extent(0, 0, 0, 0)))
 
   implicit class TypeRefinement(self: Interpreted[Result]) {
     def as[T: ClassTag]: Interpreted[T] = self match {
@@ -93,96 +93,96 @@ class EvaluationSpec extends FunSpec with Matchers with ExpressionTreeCodec {
   }
 
   it("Should interpret and evaluate tile addition") {
-    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) + IntArrayTile(1 to 4 toArray, 2, 2)).as[Tile] match {
-      case Valid(t) => t.get(0, 0) should be (2)
+    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) + IntArrayTile(1 to 4 toArray, 2, 2)).as[MultibandTile] match {
+      case Valid(t) => t.bands.head.get(0, 0) should be (2)
       case i@Invalid(_) => fail(s"$i")
     }
   }
 
   it("Should interpret and evaluate tile subtraction") {
-    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) - IntArrayTile(1 to 4 toArray, 2, 2)).as[Tile] match {
-      case Valid(t) => t.get(0, 0) should be (0)
+    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) - IntArrayTile(1 to 4 toArray, 2, 2)).as[MultibandTile] match {
+      case Valid(t) => t.bands.head.get(0, 0) should be (0)
       case i@Invalid(_) => fail(s"$i")
     }
   }
 
   it("Should interpret and evaluate tile multiplication") {
-    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) * IntArrayTile(1 to 4 toArray, 2, 2)).as[Tile] match {
-      case Valid(t) => t.get(1, 0) should be (4)
+    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) * IntArrayTile(1 to 4 toArray, 2, 2)).as[MultibandTile] match {
+      case Valid(t) => t.bands.head.get(1, 0) should be (4)
       case i@Invalid(_) => fail(s"$i")
     }
   }
 
   it("Should interpret and evaluate tile division") {
-    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) / IntArrayTile(1 to 4 toArray, 2, 2)).as[Tile] match {
-      case Valid(t) => t.get(1, 0) should be (1)
+    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) / IntArrayTile(1 to 4 toArray, 2, 2)).as[MultibandTile] match {
+      case Valid(t) => t.bands.head.get(1, 0) should be (1)
       case i@Invalid(_) => fail(s"$i")
     }
   }
 
   it("should interpret and evaluate tile comparison") {
-    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) < IntArrayTile(2 to 5 toArray, 2, 2)).as[Tile] match {
-      case Valid(t) => t.get(0, 0) should be (1)
+    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) < IntArrayTile(2 to 5 toArray, 2, 2)).as[MultibandTile] match {
+      case Valid(t) => t.bands.head.get(0, 0) should be (1)
       case i@Invalid(_) => fail(s"$i")
     }
-    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) < IntArrayTile(1 to 4 toArray, 2, 2)).as[Tile] match {
-      case Valid(t) => t.get(0, 0) should be (0)
+    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) < IntArrayTile(1 to 4 toArray, 2, 2)).as[MultibandTile] match {
+      case Valid(t) => t.bands.head.get(0, 0) should be (0)
       case i@Invalid(_) => fail(s"$i")
     }
-    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) < IntArrayTile(0 to 3 toArray, 2, 2)).as[Tile] match {
-      case Valid(t) => t.get(0, 0) should be (0)
-      case i@Invalid(_) => fail(s"$i")
-    }
-
-    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) <= IntArrayTile(2 to 5 toArray, 2, 2)).as[Tile] match {
-      case Valid(t) => t.get(0, 0) should be (1)
-      case i@Invalid(_) => fail(s"$i")
-    }
-    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) <= IntArrayTile(1 to 4 toArray, 2, 2)).as[Tile] match {
-      case Valid(t) => t.get(0, 0) should be (1)
-      case i@Invalid(_) => fail(s"$i")
-    }
-    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) <= IntArrayTile(0 to 3 toArray, 2, 2)).as[Tile] match {
-      case Valid(t) => t.get(0, 0) should be (0)
+    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) < IntArrayTile(0 to 3 toArray, 2, 2)).as[MultibandTile] match {
+      case Valid(t) => t.bands.head.get(0, 0) should be (0)
       case i@Invalid(_) => fail(s"$i")
     }
 
-    interpreter(Equal(List(IntArrayTile(1 to 4 toArray, 2, 2), IntArrayTile(2 to 5 toArray, 2, 2)))).as[Tile] match {
-      case Valid(t) => t.get(0, 0) should be (0)
+    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) <= IntArrayTile(2 to 5 toArray, 2, 2)).as[MultibandTile] match {
+      case Valid(t) => t.bands.head.get(0, 0) should be (1)
       case i@Invalid(_) => fail(s"$i")
     }
-    interpreter(Equal(List(IntArrayTile(1 to 4 toArray, 2, 2), IntArrayTile(1 to 4 toArray, 2, 2)))).as[Tile] match {
-      case Valid(t) => t.get(0, 0) should be (1)
+    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) <= IntArrayTile(1 to 4 toArray, 2, 2)).as[MultibandTile] match {
+      case Valid(t) => t.bands.head.get(0, 0) should be (1)
       case i@Invalid(_) => fail(s"$i")
     }
-    interpreter(Equal(List(IntArrayTile(1 to 4 toArray, 2, 2), IntArrayTile(0 to 3 toArray, 2, 2)))).as[Tile] match {
-      case Valid(t) => t.get(0, 0) should be (0)
-      case i@Invalid(_) => fail(s"$i")
-    }
-
-    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) >= IntArrayTile(2 to 5 toArray, 2, 2)).as[Tile] match {
-      case Valid(t) => t.get(0, 0) should be (0)
-      case i@Invalid(_) => fail(s"$i")
-    }
-    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) >= IntArrayTile(1 to 4 toArray, 2, 2)).as[Tile] match {
-      case Valid(t) => t.get(0, 0) should be (1)
-      case i@Invalid(_) => fail(s"$i")
-    }
-    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) >= IntArrayTile(0 to 3 toArray, 2, 2)).as[Tile] match {
-      case Valid(t) => t.get(0, 0) should be (1)
+    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) <= IntArrayTile(0 to 3 toArray, 2, 2)).as[MultibandTile] match {
+      case Valid(t) => t.bands.head.get(0, 0) should be (0)
       case i@Invalid(_) => fail(s"$i")
     }
 
-    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) > IntArrayTile(2 to 5 toArray, 2, 2)).as[Tile] match {
-      case Valid(t) => t.get(0, 0) should be (0)
+    interpreter(Equal(List(IntArrayTile(1 to 4 toArray, 2, 2), IntArrayTile(2 to 5 toArray, 2, 2)))).as[MultibandTile] match {
+      case Valid(t) => t.bands.head.get(0, 0) should be (0)
       case i@Invalid(_) => fail(s"$i")
     }
-    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) > IntArrayTile(1 to 4 toArray, 2, 2)).as[Tile] match {
-      case Valid(t) => t.get(0, 0) should be (0)
+    interpreter(Equal(List(IntArrayTile(1 to 4 toArray, 2, 2), IntArrayTile(1 to 4 toArray, 2, 2)))).as[MultibandTile] match {
+      case Valid(t) => t.bands.head.get(0, 0) should be (1)
       case i@Invalid(_) => fail(s"$i")
     }
-    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) > IntArrayTile(0 to 3 toArray, 2, 2)).as[Tile] match {
-      case Valid(t) => t.get(0, 0) should be (1)
+    interpreter(Equal(List(IntArrayTile(1 to 4 toArray, 2, 2), IntArrayTile(0 to 3 toArray, 2, 2)))).as[MultibandTile] match {
+      case Valid(t) => t.bands.head.get(0, 0) should be (0)
+      case i@Invalid(_) => fail(s"$i")
+    }
+
+    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) >= IntArrayTile(2 to 5 toArray, 2, 2)).as[MultibandTile] match {
+      case Valid(t) => t.bands.head.get(0, 0) should be (0)
+      case i@Invalid(_) => fail(s"$i")
+    }
+    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) >= IntArrayTile(1 to 4 toArray, 2, 2)).as[MultibandTile] match {
+      case Valid(t) => t.bands.head.get(0, 0) should be (1)
+      case i@Invalid(_) => fail(s"$i")
+    }
+    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) >= IntArrayTile(0 to 3 toArray, 2, 2)).as[MultibandTile] match {
+      case Valid(t) => t.bands.head.get(0, 0) should be (1)
+      case i@Invalid(_) => fail(s"$i")
+    }
+
+    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) > IntArrayTile(2 to 5 toArray, 2, 2)).as[MultibandTile] match {
+      case Valid(t) => t.bands.head.get(0, 0) should be (0)
+      case i@Invalid(_) => fail(s"$i")
+    }
+    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) > IntArrayTile(1 to 4 toArray, 2, 2)).as[MultibandTile] match {
+      case Valid(t) => t.bands.head.get(0, 0) should be (0)
+      case i@Invalid(_) => fail(s"$i")
+    }
+    interpreter(IntArrayTile(1 to 4 toArray, 2, 2) > IntArrayTile(0 to 3 toArray, 2, 2)).as[MultibandTile] match {
+      case Valid(t) => t.bands.head.get(0, 0) should be (1)
       case i@Invalid(_) => fail(s"$i")
     }
   }

--- a/jvm/src/test/scala/eval/ResultSpec.scala
+++ b/jvm/src/test/scala/eval/ResultSpec.scala
@@ -26,25 +26,33 @@ class ResultSpec extends FunSpec with Matchers {
   }
 
   it("Evaluate to desired output (tile)") {
-    TileResult(LazyTile(IntArrayTile(1 to 4 toArray, 2, 2), Extent(0,0,0,0))).as[Int] should be (Invalid(NEL.of(DivergingTypes("int", List("Tile")))))
-    IntResult(1).as[Tile] should matchPattern { case Invalid(_) => }
+    val anImage = ImageResult(LazyMultibandRaster(List(
+      LazyTile(IntArrayTile(1 to 4 toArray, 2, 2), Extent(0,0,0,0)))
+    ))
+    val anInt = IntResult(1)
 
-    TileResult(LazyTile(IntArrayTile(1 to 4 toArray, 2, 2), Extent(0,0,0,0))).as[Tile] should matchPattern { case Valid(_) => }
+    anImage.as[Int] should be (Invalid(NEL.of(DivergingTypes("int", List("img")))))
+    anImage.as[MultibandTile] should matchPattern { case Valid(_) => }
+    anInt.as[MultibandTile] should matchPattern { case Invalid(_) => }
 
-    TileResult(LazyTile.MapInt(List(LazyTile(IntArrayTile(1 to 4 toArray, 2, 2), Extent(0,0,0,0))), { i: Int => i + 4 }))
-      .as[Tile] should matchPattern { case Valid(_) => }
+    val complexImage = ImageResult(LazyMultibandRaster(List(
+      LazyTile.MapInt(List(LazyTile(IntArrayTile(1 to 4 toArray, 2, 2), Extent(0,0,0,0))), { i: Int => i + 4 })
+    )))
+    complexImage.as[MultibandTile] should matchPattern { case Valid(_) => }
   }
 
   it("Evaluate float tile with different cols / rows") {
     val zero = LazyTile(Raster(FloatArrayTile.fill(0, 52, 36), Extent(0, 0, 4, 4)))
     val one = LazyTile(Raster(FloatArrayTile.fill(1, 52, 36), Extent(0, 0, 4, 4)))
-    val tr = TileResult(LazyTile.DualCombine(List(zero, one), _ - _, _ - _))
-    val tile = tr.as[Tile].valueOr(r => throw new Exception(r.toString))
+    val tr = ImageResult(LazyMultibandRaster(List(
+      LazyTile.DualCombine(List(zero, one), _ - _, _ - _))
+    ))
+    val tile = tr.as[MultibandTile].valueOr(r => throw new Exception(r.toString))
 
-    tr.res.cols should be (zero.cols)
-    tr.res.rows should be (zero.rows)
+    tr.res.bands.head._2.cols should be (zero.cols)
+    tr.res.bands.head._2.rows should be (zero.rows)
 
-    tr.res.cols should be (tile.cols)
-    tr.res.rows should be (tile.rows)
+    tr.res.bands.head._2.cols should be (tile.cols)
+    tr.res.bands.head._2.rows should be (tile.rows)
   }
 }

--- a/jvm/src/test/scala/eval/ScopedEvaluationSpec.scala
+++ b/jvm/src/test/scala/eval/ScopedEvaluationSpec.scala
@@ -19,7 +19,8 @@ import scala.reflect._
 
 class ScopedEvaluationSpec extends FunSpec with Matchers {
 
-  def tileToLit(tile: Tile): RasterLit[Raster[Tile]] = RasterLit(Raster(tile, Extent(0, 0, 0, 0)))
+  def tileToLit(tile: Tile): RasterLit[Raster[MultibandTile]] =
+    RasterLit(Raster(MultibandTile(tile), Extent(0, 0, 0, 0)))
 
   implicit class TypeRefinement(self: Interpreted[Result]) {
     def as[T](implicit ct: ClassTag[T]): Interpreted[T] = self match {
@@ -31,8 +32,8 @@ class ScopedEvaluationSpec extends FunSpec with Matchers {
   val interpreter = BufferingInterpreter.DEFAULT
 
   it("Should interpret and evaluate focal operation") {
-    interpreter(FocalMax(List(tileToLit(IntArrayTile(1 to 4 toArray, 2, 2))), Square(1))).as[Tile] match {
-      case Valid(tile) => tile.get(0, 0) should be (4)
+    interpreter(FocalMax(List(tileToLit(IntArrayTile(1 to 4 toArray, 2, 2))), Square(1))).as[MultibandTile] match {
+      case Valid(tile) => tile.bands.head.get(0, 0) should be (4)
       case i@Invalid(_) => fail(s"$i")
     }
   }

--- a/jvm/src/test/scala/eval/VariableSpec.scala
+++ b/jvm/src/test/scala/eval/VariableSpec.scala
@@ -41,7 +41,7 @@ class VariableSpec extends FunSpec with Matchers {
   }
 
   it("should produce an accurate variable map with buffer in a simple case") {
-    Vars.varsWithBuffer(FocalMax(List(RasterVar("someRaster")), Square(1))) should be (Map("someRaster" -> (MamlKind.Tile, 1)))
+    Vars.varsWithBuffer(FocalMax(List(RasterVar("someRaster")), Square(1))) should be (Map("someRaster" -> (MamlKind.Image, 1)))
   }
 
   it("should produce an accurate variable map with buffer in an ambiguous case") {
@@ -52,6 +52,6 @@ class VariableSpec extends FunSpec with Matchers {
         RasterVar("someRaster")
     ))
 
-    Vars.varsWithBuffer(ast) should be (Map("someRaster" -> (MamlKind.Tile, 2)))
+    Vars.varsWithBuffer(ast) should be (Map("someRaster" -> (MamlKind.Image, 2)))
   }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,7 +13,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.24")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.25")
 
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.1.0")
 

--- a/shared/src/main/scala/ast/BinaryExpression.scala
+++ b/shared/src/main/scala/ast/BinaryExpression.scala
@@ -12,14 +12,14 @@ trait BinaryExpression { expression: Expression =>
 
 object BinaryExpression {
   def scalarCompareDerivation(k1: MamlKind, k2: MamlKind): MamlKind = (k1, k2) match {
-    case (MamlKind.Tile, MamlKind.Tile) => MamlKind.Tile
-    case (MamlKind.Tile, MamlKind.Int) => MamlKind.Tile
-    case (MamlKind.Tile, MamlKind.Double) => MamlKind.Tile
-    case (MamlKind.Int, MamlKind.Tile) => MamlKind.Tile
-    case (MamlKind.Double, MamlKind.Tile) => MamlKind.Tile
+    case (MamlKind.Image, MamlKind.Image) => MamlKind.Image
+    case (MamlKind.Image, MamlKind.Int) => MamlKind.Image
+    case (MamlKind.Image, MamlKind.Double) => MamlKind.Image
+    case (MamlKind.Int, MamlKind.Image) => MamlKind.Image
+    case (MamlKind.Double, MamlKind.Image) => MamlKind.Image
     case (MamlKind.Int, MamlKind.Int) => MamlKind.Bool
     case (MamlKind.Double, MamlKind.Double) => MamlKind.Bool
-    case (x1, x2) => throw new InvalidParameterException(s"Expected tile or scalar kinds. Found $x1 and $x2")
+    case (x1, x2) => throw new InvalidParameterException(s"Expected image or scalar kinds. Found $x1 and $x2")
   }
 }
 

--- a/shared/src/main/scala/ast/Expression.scala
+++ b/shared/src/main/scala/ast/Expression.scala
@@ -38,32 +38,32 @@ sealed abstract class Expression(val sym: String) extends Product with Serializa
 }
 
 case class Addition(children: List[Expression]) extends Expression("+") with FoldableExpression {
-  val kindDerivation = FoldableExpression.tileOrScalarDerivation(this)(_, _)
+  val kindDerivation = FoldableExpression.imageOrScalarDerivation(this)(_, _)
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
 case class Subtraction(children: List[Expression]) extends Expression("-") with FoldableExpression {
-  val kindDerivation = FoldableExpression.tileOrScalarDerivation(this)(_, _)
+  val kindDerivation = FoldableExpression.imageOrScalarDerivation(this)(_, _)
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
 case class Multiplication(children: List[Expression]) extends Expression("*") with FoldableExpression {
-  val kindDerivation = FoldableExpression.tileOrScalarDerivation(this)(_, _)
+  val kindDerivation = FoldableExpression.imageOrScalarDerivation(this)(_, _)
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
 case class Division(children: List[Expression]) extends Expression("/") with FoldableExpression {
-  val kindDerivation = FoldableExpression.tileOrScalarDerivation(this)(_, _)
+  val kindDerivation = FoldableExpression.imageOrScalarDerivation(this)(_, _)
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
 case class Max(children: List[Expression]) extends Expression("max") with FoldableExpression {
-  val kindDerivation = FoldableExpression.tileOrScalarDerivation(this)(_, _)
+  val kindDerivation = FoldableExpression.imageOrScalarDerivation(this)(_, _)
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
 case class Min(children: List[Expression]) extends Expression("min") with FoldableExpression {
-  val kindDerivation = FoldableExpression.tileOrScalarDerivation(this)(_, _)
+  val kindDerivation = FoldableExpression.imageOrScalarDerivation(this)(_, _)
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
@@ -71,9 +71,9 @@ case class Min(children: List[Expression]) extends Expression("min") with Foldab
 case class Masking(children: List[Expression]) extends Expression("mask") with BinaryExpression {
   val kindDerivation = { (k1: MamlKind, k2: MamlKind) =>
     (k1, k2) match {
-      case (MamlKind.Tile, MamlKind.Geom) => MamlKind.Tile
-      case (MamlKind.Geom, MamlKind.Tile) => MamlKind.Tile
-      case (x1, x2) => throw new InvalidParameterException(s"Expected tile and geometry kinds. Found $x1 and $x2")
+      case (MamlKind.Image, MamlKind.Geom) => MamlKind.Image
+      case (MamlKind.Geom, MamlKind.Image) => MamlKind.Image
+      case (x1, x2) => throw new InvalidParameterException(s"Expected image and geometry kinds. Found $x1 and $x2")
     }
   }
 
@@ -83,16 +83,16 @@ case class Masking(children: List[Expression]) extends Expression("mask") with B
 case class Pow(children: List[Expression]) extends Expression("**") with BinaryExpression {
   val kindDerivation = { (k1: MamlKind, k2: MamlKind) =>
     (k1, k2) match {
-      case (MamlKind.Tile, MamlKind.Tile) => MamlKind.Tile
-      case (MamlKind.Tile, MamlKind.Int) => MamlKind.Tile
-      case (MamlKind.Int, MamlKind.Tile) => MamlKind.Tile
-      case (MamlKind.Tile, MamlKind.Double) => MamlKind.Tile
-      case (MamlKind.Double, MamlKind.Tile) => MamlKind.Tile
+      case (MamlKind.Image, MamlKind.Image) => MamlKind.Image
+      case (MamlKind.Image, MamlKind.Int) => MamlKind.Image
+      case (MamlKind.Int, MamlKind.Image) => MamlKind.Image
+      case (MamlKind.Image, MamlKind.Double) => MamlKind.Image
+      case (MamlKind.Double, MamlKind.Image) => MamlKind.Image
       case (MamlKind.Double, MamlKind.Int) => MamlKind.Double
       case (MamlKind.Int, MamlKind.Double) => MamlKind.Double
       case (MamlKind.Int, MamlKind.Int) => MamlKind.Double
       case (MamlKind.Double, MamlKind.Double) => MamlKind.Double
-      case (x1, x2) => throw new InvalidParameterException(s"Expected tile and scalar kinds. Found $x1 and $x2")
+      case (x1, x2) => throw new InvalidParameterException(s"Expected image or scalar kinds. Found $x1 and $x2")
     }
   }
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
@@ -159,108 +159,108 @@ case class Branch(children: List[Expression]) extends Expression("ifelse") {
 
 /** Operations which should only have one argument. */
 case class Classification(children: List[Expression], classMap: ClassMap) extends Expression("classify") with UnaryExpression {
-  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.tileOrScalar
+  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.imageOrScalar
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
 case class Sin(children: List[Expression]) extends Expression("sin") with UnaryExpression {
-  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.tileOrScalar
+  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.imageOrScalar
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
 case class Cos(children: List[Expression]) extends Expression("cos") with UnaryExpression {
-  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.tileOrScalar
+  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.imageOrScalar
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
 case class Tan(children: List[Expression]) extends Expression("tan") with UnaryExpression {
-  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.tileOrScalar
+  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.imageOrScalar
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
 case class Sinh(children: List[Expression]) extends Expression("sinh") with UnaryExpression {
-  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.tileOrScalar
+  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.imageOrScalar
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
 case class Cosh(children: List[Expression]) extends Expression("cosh") with UnaryExpression {
-  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.tileOrScalar
+  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.imageOrScalar
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
 case class Tanh(children: List[Expression]) extends Expression("tanh") with UnaryExpression {
-  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.tileOrScalar
+  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.imageOrScalar
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
 case class Asin(children: List[Expression]) extends Expression("asin") with UnaryExpression {
-  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.tileOrScalar
+  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.imageOrScalar
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
 case class Acos(children: List[Expression]) extends Expression("acos") with UnaryExpression {
-  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.tileOrScalar
+  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.imageOrScalar
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
 case class Atan(children: List[Expression]) extends Expression("atan") with UnaryExpression {
-  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.tileOrScalar
+  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.imageOrScalar
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
 case class Round(children: List[Expression]) extends Expression("round") with UnaryExpression {
-  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.tileOrScalar
+  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.imageOrScalar
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
 case class Floor(children: List[Expression]) extends Expression("floor") with UnaryExpression {
-  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.tileOrScalar
+  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.imageOrScalar
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
 case class Ceil(children: List[Expression]) extends Expression("ceil") with UnaryExpression {
-  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.tileOrScalar
+  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.imageOrScalar
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
 /** Natural Log */
 case class LogE(children: List[Expression]) extends Expression("loge") with UnaryExpression {
-  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.tileOrScalar
+  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.imageOrScalar
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
 case class Log10(children: List[Expression]) extends Expression("log10") with UnaryExpression {
-  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.tileOrScalar
+  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.imageOrScalar
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
 case class SquareRoot(children: List[Expression]) extends Expression("sqrt") with UnaryExpression {
-  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.tileOrScalar
+  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.imageOrScalar
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
 case class Abs(children: List[Expression]) extends Expression("abs") with UnaryExpression {
-  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.tileOrScalar
+  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.imageOrScalar
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
 case class Defined(children: List[Expression]) extends Expression("def") with UnaryExpression {
-  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.tileOnly
+  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.imageOnly
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
 case class Undefined(children: List[Expression]) extends Expression("undef") with UnaryExpression {
-  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.tileOnly
+  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.imageOnly
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
 case class NumericNegation(children: List[Expression]) extends Expression("nneg") with UnaryExpression {
-  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.tileOrScalar
+  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.imageOrScalar
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
 case class LogicalNegation(children: List[Expression]) extends Expression("lneg") with UnaryExpression {
-  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.tileOnly ++ UnaryExpression.boolOnly
+  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.imageOnly ++ UnaryExpression.boolOnly
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
@@ -325,10 +325,10 @@ case class GeomVar(name: String) extends Expression("geomV") with Variable {
 }
 
 case class RasterLit[A](raster: A) extends Expression("raster") with Literal {
-  val kind = MamlKind.Tile
+  val kind = MamlKind.Image
 }
 
 case class RasterVar(name: String) extends Expression("rasterV") with Variable {
-  val kind = MamlKind.Tile
+  val kind = MamlKind.Image
 }
 

--- a/shared/src/main/scala/ast/FocalExpression.scala
+++ b/shared/src/main/scala/ast/FocalExpression.scala
@@ -8,6 +8,6 @@ import com.azavea.maml.util._
 // TODO maybe don't use lists for these unary things
 trait FocalExpression extends UnaryExpression { expression: Expression =>
   def neighborhood: Neighborhood
-  def kindDerivation: Map[MamlKind, MamlKind] = Map(MamlKind.Tile -> MamlKind.Tile)
+  def kindDerivation: Map[MamlKind, MamlKind] = Map(MamlKind.Image -> MamlKind.Image)
 }
 

--- a/shared/src/main/scala/ast/FoldableExpression.scala
+++ b/shared/src/main/scala/ast/FoldableExpression.scala
@@ -14,17 +14,17 @@ trait FoldableExpression { expression: Expression =>
 }
 
 object FoldableExpression {
-  def tileOrScalarDerivation(exp: FoldableExpression)(k1: MamlKind, k2: MamlKind): MamlKind = (k1, k2) match {
-    case (MamlKind.Tile, MamlKind.Tile) => MamlKind.Tile
+  def imageOrScalarDerivation(exp: FoldableExpression)(k1: MamlKind, k2: MamlKind): MamlKind = (k1, k2) match {
+    case (MamlKind.Image, MamlKind.Image) => MamlKind.Image
     case (MamlKind.Int, MamlKind.Int) => MamlKind.Int
-    case (MamlKind.Tile, MamlKind.Int) => MamlKind.Tile
-    case (MamlKind.Int, MamlKind.Tile) => MamlKind.Tile
+    case (MamlKind.Image, MamlKind.Int) => MamlKind.Image
+    case (MamlKind.Int, MamlKind.Image) => MamlKind.Image
     case (MamlKind.Double, MamlKind.Double) => MamlKind.Double
-    case (MamlKind.Tile, MamlKind.Double) => MamlKind.Tile
-    case (MamlKind.Double, MamlKind.Tile) => MamlKind.Tile
+    case (MamlKind.Image, MamlKind.Double) => MamlKind.Image
+    case (MamlKind.Double, MamlKind.Image) => MamlKind.Image
     case (MamlKind.Double, MamlKind.Int) => MamlKind.Double
     case (MamlKind.Int, MamlKind.Double) => MamlKind.Double
-    case (x1, x2) => throw new InvalidParameterException(s"Expected tile, int, or double kind. Found $x1 $x2")
+    case (x1, x2) => throw new InvalidParameterException(s"Expected image, int, or double kind. Found $x1 $x2")
   }
 }
 

--- a/shared/src/main/scala/ast/MamlKind.scala
+++ b/shared/src/main/scala/ast/MamlKind.scala
@@ -12,7 +12,7 @@ object MamlKind {
   case object Bool extends MamlKind { def repr: String = "bool" }
   case object Int extends MamlKind { def repr: String = "int" }
   case object Double extends MamlKind { def repr: String = "double" }
-  case object Tile extends MamlKind { def repr: String = "raster" }
+  case object Image extends MamlKind { def repr: String = "img" }
   case object Geom extends MamlKind { def repr: String = "geom" }
   // The bottom type [useful for writing inductive proofs/handling certain classes of failure]
   case object Nothing extends MamlKind { def repr: String = "nothing" }
@@ -22,7 +22,7 @@ object MamlKind {
       case "bool" => MamlKind.Bool
       case "int" => MamlKind.Int
       case "double" => MamlKind.Double
-      case "raster" => MamlKind.Tile
+      case "img" => MamlKind.Image
       case "geom" => MamlKind.Geom
       case "nothing" => MamlKind.Nothing
     }

--- a/shared/src/main/scala/ast/UnaryExpression.scala
+++ b/shared/src/main/scala/ast/UnaryExpression.scala
@@ -12,11 +12,11 @@ trait UnaryExpression { expression: Expression =>
 }
 
 object UnaryExpression {
-  val tileOnly: Map[MamlKind, MamlKind] = Map(MamlKind.Tile -> MamlKind.Tile)
+  val imageOnly: Map[MamlKind, MamlKind] = Map(MamlKind.Image -> MamlKind.Image)
   val intOnly: Map[MamlKind, MamlKind] = Map(MamlKind.Int -> MamlKind.Int)
   val dblOnly: Map[MamlKind, MamlKind] = Map(MamlKind.Double -> MamlKind.Double)
   val boolOnly: Map[MamlKind, MamlKind] = Map(MamlKind.Bool -> MamlKind.Bool)
   val scalar = intOnly ++ dblOnly
-  val tileOrScalar = tileOnly ++ intOnly ++ dblOnly
+  val imageOrScalar = imageOnly ++ intOnly ++ dblOnly
 }
 

--- a/shared/src/main/scala/ast/codec/MamlUtilityCodecs.scala
+++ b/shared/src/main/scala/ast/codec/MamlUtilityCodecs.scala
@@ -94,7 +94,7 @@ trait MamlUtilityCodecs {
   }
 
   implicit val mamlKindDecoder: Decoder[MamlKind] = Decoder[String].emap({
-    case "tile" => Right(MamlKind.Tile)
+    case "img" => Right(MamlKind.Image)
     case "int" => Right(MamlKind.Int)
     case "double" => Right(MamlKind.Double)
     case "geom" => Right(MamlKind.Geom)
@@ -104,7 +104,7 @@ trait MamlUtilityCodecs {
   implicit val mamlKindEncoder: Encoder[MamlKind] =
     Encoder.encodeString.contramap[MamlKind]({ mk =>
       mk match {
-        case MamlKind.Tile => "tile"
+        case MamlKind.Image => "img"
         case MamlKind.Int => "int"
         case MamlKind.Double => "double"
         case MamlKind.Geom => "geom"

--- a/shared/src/main/scala/dsl/Literals.scala
+++ b/shared/src/main/scala/dsl/Literals.scala
@@ -4,7 +4,7 @@ import com.azavea.maml.ast._
 
 
 trait Literals {
-  implicit def intIsIntLiteral(int: Int): IntLit= IntLit(int)
-  implicit def dblIsDoubleLiteral(dbl: Double): DblLit= DblLit(dbl)
-  implicit def boolIsBoolLiteral(bool: Boolean): BoolLit= BoolLit(bool)
+  implicit def intIsIntLiteral(int: Int): IntLit = IntLit(int)
+  implicit def dblIsDoubleLiteral(dbl: Double): DblLit = DblLit(dbl)
+  implicit def boolIsBoolLiteral(bool: Boolean): BoolLit = BoolLit(bool)
 }

--- a/shared/src/main/scala/error/MamlError.scala
+++ b/shared/src/main/scala/error/MamlError.scala
@@ -39,13 +39,6 @@ case class DivergingTypes(found: String, expected: List[String]) extends MamlErr
   def repr: String = s"Expected to evaluate tree as one of $expected; instead found $found"
 }
 
-case class UnknownTileBinding(exp: Expression, coords: Option[(Int, Int, Int)]) extends MamlError {
-  def repr: String = coords match {
-    case Some((z, x, y)) => s"Unknown retrieval error for ${exp} at SpatialKey $z, $x, $y}"
-    case None => s"Unkown retrieval error for ${exp}"
-  }
-}
-
 case class NoVariableBinding(variable: Variable, bindings: Map[String, Literal]) extends MamlError {
   def repr: String = s"No binding for ${variable.name} found in ${bindings.keys.toList}"
 }

--- a/shared/src/test/scala/ast/kind/KindSpec.scala
+++ b/shared/src/test/scala/ast/kind/KindSpec.scala
@@ -17,8 +17,8 @@ class KindSpec extends FunSpec with Matchers {
     FocalMax(List(RasterVar("test")), Square(1))
   }
 
-  it("Should correctly determine the output type for a foldable operation (tile)") {
-    Max(List(IntLit(42), RasterVar("test"), IntLit(51))).kind should be (MamlKind.Tile)
+  it("Should correctly determine the output type for a foldable operation (image)") {
+    Max(List(IntLit(42), RasterVar("test"), IntLit(51))).kind should be (MamlKind.Image)
   }
 
   it("Should correctly determine the output type for a foldable operation (scalar)") {

--- a/spark/src/main/scala/eval/RDDResult.scala
+++ b/spark/src/main/scala/eval/RDDResult.scala
@@ -21,5 +21,5 @@ case class RDDResult(res: TileLayerRDD[SpatialKey]) extends Result {
     else
       Invalid(NEL.of(DivergingTypes(cls.getName, List("SpatialRDD"))))
   }
-  def kind: MamlKind = MamlKind.Tile
+  def kind: MamlKind = MamlKind.Image
 }

--- a/spark/src/main/scala/eval/directive/RDDOpDirectives.scala
+++ b/spark/src/main/scala/eval/directive/RDDOpDirectives.scala
@@ -28,7 +28,7 @@ object RDDOpDirectives {
     grouped.getOrElse(MamlKind.Int, List.empty).map(_.as[Int]).toList.sequence
 
   private def spatialRDDResults(grouped: Map[MamlKind, Seq[Result]]): Interpreted[List[TileLayerRDD[SpatialKey]]] =
-    grouped(MamlKind.Tile).map(_.as[TileLayerRDD[SpatialKey]]).toList.sequence
+    grouped(MamlKind.Image).map(_.as[TileLayerRDD[SpatialKey]]).toList.sequence
 
   /** Some sugar to wrap a common pattern. */
   def unary(f: RDD[(SpatialKey,Tile)] => RDD[(SpatialKey,Tile)], r: TileLayerRDD[SpatialKey]): Interpreted[Result] =


### PR DESCRIPTION
Multiband tiles (and labelled imagery, allowing for literate trees) are added with this PR. `LazyMultibandRaster` is the type doing much of the heavy lifting. Apart from that, the `Result` type for imagery has changed to accommodate the new form of output.