### PR TITLE
Unify all interpreter types

### DIFF
--- a/jvm/src/main/scala/eval/Interpreter.scala
+++ b/jvm/src/main/scala/eval/Interpreter.scala
@@ -12,13 +12,10 @@ import scala.reflect.ClassTag
 
 
 trait Interpreter {
-  def fallbackDirective: Directive
-  def instructions(expression: Expression, children: List[Result]): Interpreted[Result]
-  def appendDirective(directive: Directive): Interpreter
-  def prependDirective(directive: Directive): Interpreter
-  def apply(exp: Expression): Interpreted[Result] = {
-    val children: Interpreted[List[Result]] = exp.children.map(apply).sequence
-    children.andThen({ childRes => instructions(exp, childRes) })
-  }
+  def apply(exp: Expression): Interpreted[Result]
+}
+
+object Interpreter {
+  val DEFAULT = NaiveInterpreter.DEFAULT
 }
 

--- a/jvm/src/main/scala/eval/NaiveInterpreter.scala
+++ b/jvm/src/main/scala/eval/NaiveInterpreter.scala
@@ -14,6 +14,11 @@ import scala.reflect.ClassTag
 
 case class NaiveInterpreter(directives: List[Directive]) extends Interpreter {
 
+  def apply(exp: Expression): Interpreted[Result] = {
+    val children: Interpreted[List[Result]] = exp.children.map(apply).sequence
+    children.andThen({ childRes => instructions(exp, childRes) })
+  }
+
   def prependDirective(directive: Directive): Interpreter =
     NaiveInterpreter(directive +: directives)
 

--- a/jvm/src/main/scala/eval/ScopedInterpreter.scala
+++ b/jvm/src/main/scala/eval/ScopedInterpreter.scala
@@ -10,21 +10,23 @@ import cats.data.{NonEmptyList => NEL, _}
 import geotrellis.raster.GridBounds
 
 
-trait ScopedInterpreter[Scope] {
+trait ScopedInterpreter[Scope] extends Interpreter {
   def scopeFor(exp: Expression, previous: Option[Scope]): Scope
   def appendDirective(directive: ScopedDirective[Scope]): ScopedInterpreter[Scope]
   def prependDirective(directive: ScopedDirective[Scope]): ScopedInterpreter[Scope]
   def fallbackDirective: ScopedDirective[Scope]
   def instructions(expression: Expression, children: Seq[Result], scope: Scope): Interpreted[Result]
 
-  def apply(exp: Expression, maybeScope: Option[Scope] = None): Interpreted[Result] = {
-    val currentScope = scopeFor(exp, maybeScope)
-    val children: Interpreted[List[Result]] = exp.children.map({ childTree =>
-      val childScope = scopeFor(childTree, Some(currentScope))
-      apply(childTree, Some(childScope))
-    }).sequence
-
-    children.andThen({ childResult => instructions(exp, childResult, currentScope) })
+  def apply(exp: Expression): Interpreted[Result] = {
+    def eval(exp: Expression, maybeScope: Option[Scope] = None): Interpreted[Result] = {
+      val currentScope = scopeFor(exp, maybeScope)
+      val children: Interpreted[List[Result]] = exp.children.map({ childTree =>
+        val childScope = scopeFor(childTree, Some(currentScope))
+        eval(childTree, Some(childScope))
+      }).sequence
+      children.andThen({ childResult => instructions(exp, childResult, currentScope) })
+    }
+    eval(exp)
   }
 }
 


### PR DESCRIPTION
By removing unnecessary properties from the unifying `Interpreter` trait and constructing the more complex 'scoped' evaluation recursion within the `apply` method, we can unify the `Interpreter` type (so that naive and scoped interpreters can be used interchangeably - though `BufferingInterpreter` will run some risk of runtime issues for extents as of now)