### PR TITLE
Add support for focal slope

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.scalapenos.sbt.prompt.SbtPrompt.autoImport._
 
 promptTheme := com.scalapenos.sbt.prompt.PromptThemes.ScalapenosTheme
 
-val mamlVersion = "0.1.10" + scala.util.Properties.envOrElse("MAML_VERSION_SUFFIX", "")
+val mamlVersion = "0.2.0-LOCAL"
 
 /** Project configurations */
 lazy val root = project.in(file("."))

--- a/jvm/src/main/scala/dsl/tile/LazyTileMethods.scala
+++ b/jvm/src/main/scala/dsl/tile/LazyTileMethods.scala
@@ -7,257 +7,257 @@ import geotrellis.raster.render.BreakMap
 import geotrellis.raster.mapalgebra.local._
 
 
-trait LazyTileOperations {
-  val self: LazyTile
+trait LazyRasterOperations {
+  val self: LazyRaster
 
   /** Arithmetic Operations*/
-  def +(other: LazyTile): LazyTile = LazyTile.DualCombine(List(self, other), Add.combine, Add.combine)
-  def +(other: Int): LazyTile = LazyTile.DualMap(List(self), { Add.combine(_, other) }, { Add.combine(_, other) })
-  def +:(other: Int): LazyTile = LazyTile.DualMap(List(self), { Add.combine(other, _) }, { Add.combine(other, _) })
-  def +(other: Double): LazyTile = LazyTile.DualMap(List(self), { Add.combine(_, d2i(other)) }, { Add.combine(_, other) })
-  def +:(other: Double): LazyTile = LazyTile.DualMap(List(self), { Add.combine(d2i(other), _) }, { Add.combine(other, _) })
+  def +(other: LazyRaster): LazyRaster = LazyRaster.DualCombine(List(self, other), Add.combine, Add.combine)
+  def +(other: Int): LazyRaster = LazyRaster.DualMap(List(self), { Add.combine(_, other) }, { Add.combine(_, other) })
+  def +:(other: Int): LazyRaster = LazyRaster.DualMap(List(self), { Add.combine(other, _) }, { Add.combine(other, _) })
+  def +(other: Double): LazyRaster = LazyRaster.DualMap(List(self), { Add.combine(_, d2i(other)) }, { Add.combine(_, other) })
+  def +:(other: Double): LazyRaster = LazyRaster.DualMap(List(self), { Add.combine(d2i(other), _) }, { Add.combine(other, _) })
 
-  def -(other: LazyTile): LazyTile = LazyTile.DualCombine(List(self, other), Subtract.combine, Subtract.combine)
-  def -(other: Int): LazyTile = LazyTile.DualMap(List(self), { Subtract.combine(_, other) }, { Subtract.combine(_, i2d(other)) })
-  def -:(other: Int): LazyTile = LazyTile.DualMap(List(self), { Subtract.combine(other, _) }, { Subtract.combine(i2d(other), _) })
-  def -(other: Double): LazyTile = LazyTile.DualMap(List(self), { Subtract.combine(_, d2i(other)) }, { Subtract.combine(_, other) })
-  def -:(other: Double): LazyTile = LazyTile.DualMap(List(self), { Subtract.combine(d2i(other), _) }, { Subtract.combine(other, _) })
+  def -(other: LazyRaster): LazyRaster = LazyRaster.DualCombine(List(self, other), Subtract.combine, Subtract.combine)
+  def -(other: Int): LazyRaster = LazyRaster.DualMap(List(self), { Subtract.combine(_, other) }, { Subtract.combine(_, i2d(other)) })
+  def -:(other: Int): LazyRaster = LazyRaster.DualMap(List(self), { Subtract.combine(other, _) }, { Subtract.combine(i2d(other), _) })
+  def -(other: Double): LazyRaster = LazyRaster.DualMap(List(self), { Subtract.combine(_, d2i(other)) }, { Subtract.combine(_, other) })
+  def -:(other: Double): LazyRaster = LazyRaster.DualMap(List(self), { Subtract.combine(d2i(other), _) }, { Subtract.combine(other, _) })
 
-  def *(other: LazyTile): LazyTile = LazyTile.DualCombine(List(self, other), Multiply.combine, Multiply.combine)
-  def *(other: Int): LazyTile = LazyTile.DualMap(List(self), { Multiply.combine(_, other) }, { Multiply.combine(_, i2d(other)) })
-  def *:(other: Int): LazyTile = LazyTile.DualMap(List(self), { Multiply.combine(other, _) }, { Multiply.combine(i2d(other), _) })
-  def *(other: Double): LazyTile = LazyTile.DualMap(List(self), { Multiply.combine(_, d2i(other)) }, { Multiply.combine(_, other) })
-  def *:(other: Double): LazyTile = LazyTile.DualMap(List(self), { Multiply.combine(d2i(other), _) }, { Multiply.combine(other, _) })
+  def *(other: LazyRaster): LazyRaster = LazyRaster.DualCombine(List(self, other), Multiply.combine, Multiply.combine)
+  def *(other: Int): LazyRaster = LazyRaster.DualMap(List(self), { Multiply.combine(_, other) }, { Multiply.combine(_, i2d(other)) })
+  def *:(other: Int): LazyRaster = LazyRaster.DualMap(List(self), { Multiply.combine(other, _) }, { Multiply.combine(i2d(other), _) })
+  def *(other: Double): LazyRaster = LazyRaster.DualMap(List(self), { Multiply.combine(_, d2i(other)) }, { Multiply.combine(_, other) })
+  def *:(other: Double): LazyRaster = LazyRaster.DualMap(List(self), { Multiply.combine(d2i(other), _) }, { Multiply.combine(other, _) })
 
-  def /(other: LazyTile): LazyTile = LazyTile.DualCombine(List(self, other), Divide.combine, Divide.combine)
-  def /(other: Int): LazyTile = LazyTile.DualMap(List(self), { Divide.combine(_, other) }, { Divide.combine(_, i2d(other)) })
-  def /:(other: Int): LazyTile = LazyTile.DualMap(List(self), { Divide.combine(other, _) }, { Divide.combine(i2d(other), _) })
-  def /(other: Double): LazyTile = LazyTile.DualMap(List(self), { Divide.combine(_, d2i(other)) }, { Divide.combine(_, other) })
-  def /:(other: Double): LazyTile = LazyTile.DualMap(List(self), { Divide.combine(d2i(other), _) }, { Divide.combine(other, _) })
+  def /(other: LazyRaster): LazyRaster = LazyRaster.DualCombine(List(self, other), Divide.combine, Divide.combine)
+  def /(other: Int): LazyRaster = LazyRaster.DualMap(List(self), { Divide.combine(_, other) }, { Divide.combine(_, i2d(other)) })
+  def /:(other: Int): LazyRaster = LazyRaster.DualMap(List(self), { Divide.combine(other, _) }, { Divide.combine(i2d(other), _) })
+  def /(other: Double): LazyRaster = LazyRaster.DualMap(List(self), { Divide.combine(_, d2i(other)) }, { Divide.combine(_, other) })
+  def /:(other: Double): LazyRaster = LazyRaster.DualMap(List(self), { Divide.combine(d2i(other), _) }, { Divide.combine(other, _) })
 
-  def **(other: LazyTile): LazyTile = LazyTile.DualCombine(List(self, other), Pow.combine, Pow.combine)
-  def **(other: Int): LazyTile = LazyTile.DualMap(List(self), { Pow.combine(_, other) }, { Pow.combine(_, i2d(other)) })
-  def **:(other: Int): LazyTile = LazyTile.DualMap(List(self), { Pow.combine(other, _) }, { Pow.combine(i2d(other), _) })
-  def **(other: Double): LazyTile = LazyTile.DualMap(List(self), { Pow.combine(_, d2i(other)) }, { Pow.combine(_, other) })
-  def **:(other: Double): LazyTile = LazyTile.DualMap(List(self), { Pow.combine(d2i(other), _) }, { Pow.combine(other, _) })
+  def **(other: LazyRaster): LazyRaster = LazyRaster.DualCombine(List(self, other), Pow.combine, Pow.combine)
+  def **(other: Int): LazyRaster = LazyRaster.DualMap(List(self), { Pow.combine(_, other) }, { Pow.combine(_, i2d(other)) })
+  def **:(other: Int): LazyRaster = LazyRaster.DualMap(List(self), { Pow.combine(other, _) }, { Pow.combine(i2d(other), _) })
+  def **(other: Double): LazyRaster = LazyRaster.DualMap(List(self), { Pow.combine(_, d2i(other)) }, { Pow.combine(_, other) })
+  def **:(other: Double): LazyRaster = LazyRaster.DualMap(List(self), { Pow.combine(d2i(other), _) }, { Pow.combine(other, _) })
 
 
-  def logE: LazyTile = LazyTile.DualMap(List(self),
+  def logE: LazyRaster = LazyRaster.DualMap(List(self),
     { z: Int => if(isNoData(z)) z else d2i(math.log(i2d(z))) },
     { z => if(isNoData(z)) z else math.log(z) }
   )
 
-  def log10: LazyTile = LazyTile.DualMap(List(self),
+  def log10: LazyRaster = LazyRaster.DualMap(List(self),
     { z: Int => if(isNoData(z)) z else d2i(math.log10(i2d(z))) },
     { z => if(isNoData(z)) z else math.log10(z) }
   )
 
-  def sqrt: LazyTile = LazyTile.DualMap(List(self),
+  def sqrt: LazyRaster = LazyRaster.DualMap(List(self),
     { z: Int => if(isNoData(z)) z else d2i(math.sqrt(i2d(z))) },
     { z => if(isNoData(z)) z else math.sqrt(z) }
   )
 
-  def abs: LazyTile = LazyTile.DualMap(List(self),
+  def abs: LazyRaster = LazyRaster.DualMap(List(self),
     { z: Int => if(isNoData(z)) z else math.abs(z) },
     { z => if(isNoData(z)) z else math.abs(z) }
   )
 
-  def isDefined: LazyTile = LazyTile.DualMap(List(self),
+  def isDefined: LazyRaster = LazyRaster.DualMap(List(self),
     { z: Int => if (isData(z)) 1 else 0 },
     { z => if (isData(z)) 1.0 else 0.0 }
   )
 
-  def isUndefined: LazyTile = LazyTile.DualMap(List(self),
+  def isUndefined: LazyRaster = LazyRaster.DualMap(List(self),
     { z: Int => if (isNoData(z)) 1 else 0 },
     { z => if (isNoData(z)) 1.0 else 0.0 }
   )
 
-  def pow(i: Int): LazyTile = LazyTile.DualMap(List(self),
+  def pow(i: Int): LazyRaster = LazyRaster.DualMap(List(self),
     { z: Int => if (isNoData(z)) 1 else 0 },
     { z => if (isNoData(z)) 1.0 else 0.0 }
   )
 
-  def pow(d: Double): LazyTile = LazyTile.DualMap(List(self),
+  def pow(d: Double): LazyRaster = LazyRaster.DualMap(List(self),
     { z: Int => if (isNoData(z)) 1 else 0 },
     { z => if (isNoData(z)) 1.0 else 0.0 }
   )
 
-  def changeSign: LazyTile = LazyTile.DualMap(List(self),
+  def changeSign: LazyRaster = LazyRaster.DualMap(List(self),
     { z: Int => if (isNoData(z)) z else z * -1 },
     { z => if (isNoData(z)) z else z * - 1 }
   )
 
   /** Numeric Comparisons */
-  def <(other: LazyTile): LazyTile =
-    LazyTile.DualCombine(List(self, other),
+  def <(other: LazyRaster): LazyRaster =
+    LazyRaster.DualCombine(List(self, other),
       {(i1: Int, i2: Int) => if (Less.compare(i1, i2)) 1 else 0 },
       {(d1: Double, d2: Double) => if (Less.compare(d1, d2)) 1.0 else 0.0 }
     )
-  def <(other: Int): LazyTile =
-    LazyTile.DualMap(List(self),
+  def <(other: Int): LazyRaster =
+    LazyRaster.DualMap(List(self),
       {(i: Int) => if (Less.compare(i, other.toInt)) 1 else 0},
       {(d: Double) => if (Less.compare(d, other)) 1.0 else 0.0 }
     )
-  def <(other: Double): LazyTile =
-    LazyTile.DualMap(List(self),
+  def <(other: Double): LazyRaster =
+    LazyRaster.DualMap(List(self),
       {(i: Int) => if (Less.compare(i, other.toInt)) 1 else 0},
       {(d: Double) => if (Less.compare(d, other)) 1.0 else 0.0 }
     )
 
-  def <=(other: LazyTile): LazyTile =
-    LazyTile.DualCombine(List(self, other),
+  def <=(other: LazyRaster): LazyRaster =
+    LazyRaster.DualCombine(List(self, other),
       {(i1: Int, i2: Int) => if (LessOrEqual.compare(i1, i2)) 1 else 0 },
       {(d1: Double, d2: Double) => if (LessOrEqual.compare(d1, d2)) 1.0 else 0.0 }
     )
-  def <=(other: Int): LazyTile =
-    LazyTile.DualMap(List(self),
+  def <=(other: Int): LazyRaster =
+    LazyRaster.DualMap(List(self),
       {(i: Int) => if (LessOrEqual.compare(i, other.toInt)) 1 else 0},
       {(d: Double) => if (LessOrEqual.compare(d, other)) 1.0 else 0.0 }
     )
-  def <=(other: Double): LazyTile =
-    LazyTile.DualMap(List(self),
+  def <=(other: Double): LazyRaster =
+    LazyRaster.DualMap(List(self),
       {(i: Int) => if (LessOrEqual.compare(i, other.toInt)) 1 else 0},
       {(d: Double) => if (LessOrEqual.compare(d, other)) 1.0 else 0.0 }
     )
 
-  def ===(other: LazyTile): LazyTile =
-    LazyTile.DualCombine(List(self, other),
+  def ===(other: LazyRaster): LazyRaster =
+    LazyRaster.DualCombine(List(self, other),
       {(i1: Int, i2: Int) => if (Equal.compare(i1, i2)) 1 else 0 },
       {(d1: Double, d2: Double) => if (Equal.compare(d1, d2)) 1.0 else 0.0 }
     )
-  def ===(other: Int): LazyTile =
-    LazyTile.DualMap(List(self),
+  def ===(other: Int): LazyRaster =
+    LazyRaster.DualMap(List(self),
       {(i: Int) => if (Equal.compare(i, other.toInt)) 1 else 0},
       {(d: Double) => if (Equal.compare(d, other)) 1.0 else 0.0 }
     )
-  def ===(other: Double): LazyTile =
-    LazyTile.DualMap(List(self),
+  def ===(other: Double): LazyRaster =
+    LazyRaster.DualMap(List(self),
       {(i: Int) => if (Equal.compare(i, other.toInt)) 1 else 0},
       {(d: Double) => if (Equal.compare(d, other)) 1.0 else 0.0 }
     )
 
-  def !==(other: LazyTile): LazyTile =
-    LazyTile.DualCombine(List(self, other),
+  def !==(other: LazyRaster): LazyRaster =
+    LazyRaster.DualCombine(List(self, other),
       {(i1: Int, i2: Int) => if (Unequal.compare(i1, i2)) 1 else 0 },
       {(d1: Double, d2: Double) => if (Unequal.compare(d1, d2)) 1.0 else 0.0 }
     )
-  def !==(other: Int): LazyTile =
-    LazyTile.DualMap(List(self),
+  def !==(other: Int): LazyRaster =
+    LazyRaster.DualMap(List(self),
       {(i: Int) => if (Unequal.compare(i, other.toInt)) 1 else 0},
       {(d: Double) => if (Unequal.compare(d, other)) 1.0 else 0.0 }
     )
-  def !==(other: Double): LazyTile =
-    LazyTile.DualMap(List(self),
+  def !==(other: Double): LazyRaster =
+    LazyRaster.DualMap(List(self),
       {(i: Int) => if (Unequal.compare(i, other.toInt)) 1 else 0},
       {(d: Double) => if (Unequal.compare(d, other)) 1.0 else 0.0 }
     )
 
-  def >=(other: LazyTile): LazyTile =
-    LazyTile.DualCombine(List(self, other),
+  def >=(other: LazyRaster): LazyRaster =
+    LazyRaster.DualCombine(List(self, other),
       {(i1: Int, i2: Int) => if (GreaterOrEqual.compare(i1, i2)) 1 else 0 },
       {(d1: Double, d2: Double) => if (GreaterOrEqual.compare(d1, d2)) 1.0 else 0.0 }
     )
-  def >=(other: Int): LazyTile =
-    LazyTile.DualMap(List(self),
+  def >=(other: Int): LazyRaster =
+    LazyRaster.DualMap(List(self),
       {(i: Int) => if (GreaterOrEqual.compare(i, other.toInt)) 1 else 0},
       {(d: Double) => if (GreaterOrEqual.compare(d, other)) 1.0 else 0.0 }
     )
-  def >=(other: Double): LazyTile =
-    LazyTile.DualMap(List(self),
+  def >=(other: Double): LazyRaster =
+    LazyRaster.DualMap(List(self),
       {(i: Int) => if (GreaterOrEqual.compare(i, other.toInt)) 1 else 0},
       {(d: Double) => if (GreaterOrEqual.compare(d, other)) 1.0 else 0.0 }
     )
 
-  def >(other: LazyTile): LazyTile =
-    LazyTile.DualCombine(List(self, other),
+  def >(other: LazyRaster): LazyRaster =
+    LazyRaster.DualCombine(List(self, other),
       {(i1: Int, i2: Int) => if (Greater.compare(i1, i2)) 1 else 0 },
       {(d1: Double, d2: Double) => if (Greater.compare(d1, d2)) 1.0 else 0.0 }
     )
-  def >(other: Int): LazyTile =
-    LazyTile.DualMap(List(self),
+  def >(other: Int): LazyRaster =
+    LazyRaster.DualMap(List(self),
       {(i: Int) => if (Greater.compare(i, other.toInt)) 1 else 0},
       {(d: Double) => if (Greater.compare(d, other)) 1.0 else 0.0 }
     )
-  def >(other: Double): LazyTile =
-    LazyTile.DualMap(List(self),
+  def >(other: Double): LazyRaster =
+    LazyRaster.DualMap(List(self),
       {(i: Int) => if (Greater.compare(i, other.toInt)) 1 else 0},
       {(d: Double) => if (Greater.compare(d, other)) 1.0 else 0.0 }
     )
 
   /** Trigonometric Operations */
-  def sin: LazyTile = LazyTile.DualMap(List(self),
+  def sin: LazyRaster = LazyRaster.DualMap(List(self),
     { z: Int => if(isNoData(z)) z else d2i(math.sin(z)) },
     { z => if(isNoData(z)) z else math.sin(z) }
   )
-  def cos: LazyTile = LazyTile.DualMap(List(self),
+  def cos: LazyRaster = LazyRaster.DualMap(List(self),
     { z: Int => if(isNoData(z)) z else d2i(math.cos(z)) },
     { z => if(isNoData(z)) z else math.cos(z) }
   )
-  def tan: LazyTile = LazyTile.DualMap(List(self),
+  def tan: LazyRaster = LazyRaster.DualMap(List(self),
     { z: Int => if(isNoData(z)) z else d2i(math.tan(z)) },
     { z => if(isNoData(z)) z else math.tan(z) }
   )
 
-  def sinh: LazyTile = LazyTile.DualMap(List(self),
+  def sinh: LazyRaster = LazyRaster.DualMap(List(self),
     { z: Int => if(isNoData(z)) z else d2i(math.sinh(z)) },
     { z => if(isNoData(z)) z else math.sinh(z) }
   )
-  def cosh: LazyTile = LazyTile.DualMap(List(self),
+  def cosh: LazyRaster = LazyRaster.DualMap(List(self),
     { z: Int => if(isNoData(z)) z else d2i(math.cosh(z)) },
     { z => if(isNoData(z)) z else math.cosh(z) }
   )
-  def tanh: LazyTile = LazyTile.DualMap(List(self),
+  def tanh: LazyRaster = LazyRaster.DualMap(List(self),
     { z: Int => if(isNoData(z)) z else d2i(math.tanh(z)) },
     { z => if(isNoData(z)) z else math.tanh(z) }
   )
 
-  def asin: LazyTile = LazyTile.DualMap(List(self),
+  def asin: LazyRaster = LazyRaster.DualMap(List(self),
     { z: Int => if(isNoData(z)) z else d2i(math.asin(z)) },
     { z => if(isNoData(z)) z else math.asin(z) }
   )
-  def acos: LazyTile = LazyTile.DualMap(List(self),
+  def acos: LazyRaster = LazyRaster.DualMap(List(self),
     { z: Int => if(isNoData(z)) z else d2i(math.acos(z)) },
     { z => if(isNoData(z)) z else math.acos(z) }
   )
-  def atan: LazyTile = LazyTile.DualMap(List(self),
+  def atan: LazyRaster = LazyRaster.DualMap(List(self),
     { z: Int => if(isNoData(z)) z else d2i(math.atan(z)) },
     { z => if(isNoData(z)) z else math.atan(z) }
   )
 
-  def atan2(other: LazyTile) = LazyTile.DualCombine(List(self, other), { (z1, z2) => d2i(math.atan2(i2d(z1), i2d(z2))) }, { (z1, z2) => math.atan2(z1, z2) })
-  def atan2(other: Int): LazyTile = LazyTile.DualMap(List(self), { i: Int => d2i(math.atan2(i, other)) }, { math.atan2(_, other) })
-  def atan2(other: Double): LazyTile = LazyTile.DualMap(List(self), { i: Int => d2i(math.atan2(i, other)) }, { math.atan2(_, other) })
+  def atan2(other: LazyRaster) = LazyRaster.DualCombine(List(self, other), { (z1, z2) => d2i(math.atan2(i2d(z1), i2d(z2))) }, { (z1, z2) => math.atan2(z1, z2) })
+  def atan2(other: Int): LazyRaster = LazyRaster.DualMap(List(self), { i: Int => d2i(math.atan2(i, other)) }, { math.atan2(_, other) })
+  def atan2(other: Double): LazyRaster = LazyRaster.DualMap(List(self), { i: Int => d2i(math.atan2(i, other)) }, { math.atan2(_, other) })
 
   /** Rounding Operations */
-  def round: LazyTile = LazyTile.DualMap(List(self), identity, { z => if(isNoData(z)) z else math.round(z) })
+  def round: LazyRaster = LazyRaster.DualMap(List(self), identity, { z => if(isNoData(z)) z else math.round(z) })
 
-  def floor: LazyTile = LazyTile.DualMap(List(self), identity, { z => if(isNoData(z)) z else math.floor(z) })
+  def floor: LazyRaster = LazyRaster.DualMap(List(self), identity, { z => if(isNoData(z)) z else math.floor(z) })
 
-  def ceil: LazyTile = LazyTile.DualMap(List(self), identity, { z => if(isNoData(z)) z else math.ceil(z) })
+  def ceil: LazyRaster = LazyRaster.DualMap(List(self), identity, { z => if(isNoData(z)) z else math.ceil(z) })
 
   /** Logical Operations */
   // TODO: Look into GT implementations for logical operations...
   //       The handling of nodata vs 0 vs false is not obvious
-  def &&(other: LazyTile): LazyTile = LazyTile.DualCombine(List(self, other), And.combine, And.combine)
-  def &&(other: Int): LazyTile = LazyTile.DualMap(List(self), { And.combine(_, other) }, { And.combine(_, other) })
-  def &&:(other: Int): LazyTile = LazyTile.DualMap(List(self), { And.combine(_, other) }, { And.combine(_, other) })
-  def &&(other: Double): LazyTile = LazyTile.DualMap(List(self), { And.combine(_, d2i(other)) }, { And.combine(_, other) })
-  def &&:(other: Double): LazyTile = LazyTile.DualMap(List(self), { And.combine(_, d2i(other)) }, { And.combine(_, other) })
+  def &&(other: LazyRaster): LazyRaster = LazyRaster.DualCombine(List(self, other), And.combine, And.combine)
+  def &&(other: Int): LazyRaster = LazyRaster.DualMap(List(self), { And.combine(_, other) }, { And.combine(_, other) })
+  def &&:(other: Int): LazyRaster = LazyRaster.DualMap(List(self), { And.combine(_, other) }, { And.combine(_, other) })
+  def &&(other: Double): LazyRaster = LazyRaster.DualMap(List(self), { And.combine(_, d2i(other)) }, { And.combine(_, other) })
+  def &&:(other: Double): LazyRaster = LazyRaster.DualMap(List(self), { And.combine(_, d2i(other)) }, { And.combine(_, other) })
 
-  def ||(other: LazyTile): LazyTile = LazyTile.DualCombine(List(self, other), Or.combine, Or.combine)
-  def ||(other: Int): LazyTile = LazyTile.DualMap(List(self), { Or.combine(_, other) }, { Or.combine(_, other) })
-  def ||:(other: Int): LazyTile = LazyTile.DualMap(List(self), { Or.combine(_, other) }, { Or.combine(_, other) })
-  def ||(other: Double): LazyTile = LazyTile.DualMap(List(self), { Or.combine(_, d2i(other)) }, { Or.combine(_, other) })
-  def ||:(other: Double): LazyTile = LazyTile.DualMap(List(self), { Or.combine(_, d2i(other)) }, { Or.combine(_, other) })
+  def ||(other: LazyRaster): LazyRaster = LazyRaster.DualCombine(List(self, other), Or.combine, Or.combine)
+  def ||(other: Int): LazyRaster = LazyRaster.DualMap(List(self), { Or.combine(_, other) }, { Or.combine(_, other) })
+  def ||:(other: Int): LazyRaster = LazyRaster.DualMap(List(self), { Or.combine(_, other) }, { Or.combine(_, other) })
+  def ||(other: Double): LazyRaster = LazyRaster.DualMap(List(self), { Or.combine(_, d2i(other)) }, { Or.combine(_, other) })
+  def ||:(other: Double): LazyRaster = LazyRaster.DualMap(List(self), { Or.combine(_, d2i(other)) }, { Or.combine(_, other) })
 
-  def xor(other: LazyTile): LazyTile = LazyTile.DualCombine(List(self, other), Xor.combine, Xor.combine)
-  def xor(other: Int): LazyTile = LazyTile.DualMap(List(self), { Xor.combine(_, other) }, { Xor.combine(_, other) })
-  def xor(other: Double): LazyTile = LazyTile.DualMap(List(self), { Xor.combine(_, d2i(other)) }, { Xor.combine(_, other) })
+  def xor(other: LazyRaster): LazyRaster = LazyRaster.DualCombine(List(self, other), Xor.combine, Xor.combine)
+  def xor(other: Int): LazyRaster = LazyRaster.DualMap(List(self), { Xor.combine(_, other) }, { Xor.combine(_, other) })
+  def xor(other: Double): LazyRaster = LazyRaster.DualMap(List(self), { Xor.combine(_, d2i(other)) }, { Xor.combine(_, other) })
 
-  def not: LazyTile = LazyTile.DualMap(List(self), { z => if (isNoData(z)) z else if (z == 0) 1 else 0 }, { z => if (isNoData(z)) z else if (z == 0.0) 1.0 else 0.0 })
+  def not: LazyRaster = LazyRaster.DualMap(List(self), { z => if (isNoData(z)) z else if (z == 0) 1 else 0 }, { z => if (isNoData(z)) z else if (z == 0.0) 1.0 else 0.0 })
 
   /** Tile specific methods */
-  def classify(breaks: BreakMap[Double, Int]) = LazyTile.DualMap(List(self), { i => breaks(i2d(i)) }, { d => i2d(breaks(d)) })
+  def classify(breaks: BreakMap[Double, Int]) = LazyRaster.DualMap(List(self), { i => breaks(i2d(i)) }, { d => i2d(breaks(d)) })
 
 }
 

--- a/jvm/src/main/scala/dsl/tile/package.scala
+++ b/jvm/src/main/scala/dsl/tile/package.scala
@@ -4,6 +4,6 @@ import com.azavea.maml.eval.tile._
 
 
 package object tile {
-  implicit class LazyTileExtensions(val self: LazyTile) extends LazyTileOperations
+  implicit class LazyRasterExtensions(val self: LazyRaster) extends LazyRasterOperations
   implicit class LazyMultibandRasterExtensions(val self: LazyMultibandRaster) extends LazyMultibandRasterOperations
 }

--- a/jvm/src/main/scala/eval/BufferingInterpreter.scala
+++ b/jvm/src/main/scala/eval/BufferingInterpreter.scala
@@ -102,7 +102,8 @@ object BufferingInterpreter {
       focalMode,
       focalMedian,
       focalSum,
-      focalStandardDeviation
+      focalStandardDeviation,
+      ScopedDirective.pure[FocalSlope](FocalDirectives.slope)
     ), Options(256)
   )
 

--- a/jvm/src/main/scala/eval/Interpreter.scala
+++ b/jvm/src/main/scala/eval/Interpreter.scala
@@ -12,13 +12,10 @@ import scala.reflect.ClassTag
 
 
 trait Interpreter {
-  def fallbackDirective: Directive
-  def instructions(expression: Expression, children: List[Result]): Interpreted[Result]
-  def appendDirective(directive: Directive): Interpreter
-  def prependDirective(directive: Directive): Interpreter
-  def apply(exp: Expression): Interpreted[Result] = {
-    val children: Interpreted[List[Result]] = exp.children.map(apply).sequence
-    children.andThen({ childRes => instructions(exp, childRes) })
-  }
+  def apply(exp: Expression): Interpreted[Result]
+}
+
+object Interpreter {
+  val DEFAULT = NaiveInterpreter.DEFAULT
 }
 

--- a/jvm/src/main/scala/eval/NaiveInterpreter.scala
+++ b/jvm/src/main/scala/eval/NaiveInterpreter.scala
@@ -87,7 +87,8 @@ object NaiveInterpreter {
       FocalDirectives.mode,
       FocalDirectives.median,
       FocalDirectives.sum,
-      FocalDirectives.standardDeviation
+      FocalDirectives.standardDeviation,
+      FocalDirectives.slope
     )
   )
 }

--- a/jvm/src/main/scala/eval/NaiveInterpreter.scala
+++ b/jvm/src/main/scala/eval/NaiveInterpreter.scala
@@ -14,6 +14,11 @@ import scala.reflect.ClassTag
 
 case class NaiveInterpreter(directives: List[Directive]) extends Interpreter {
 
+  def apply(exp: Expression): Interpreted[Result] = {
+    val children: Interpreted[List[Result]] = exp.children.map(apply).sequence
+    children.andThen({ childRes => instructions(exp, childRes) })
+  }
+
   def prependDirective(directive: Directive): Interpreter =
     NaiveInterpreter(directive +: directives)
 

--- a/jvm/src/main/scala/eval/Result.scala
+++ b/jvm/src/main/scala/eval/Result.scala
@@ -5,7 +5,7 @@ import com.azavea.maml.error._
 import com.azavea.maml.eval._
 import com.azavea.maml.eval.tile._
 
-import geotrellis.raster.MultibandTile
+import geotrellis.raster._
 import geotrellis.raster.io.geotiff.MultibandGeoTiff
 import geotrellis.vector.Geometry
 import cats.data.{NonEmptyList => NEL, _}
@@ -61,8 +61,10 @@ case class ImageResult(res: LazyMultibandRaster) extends Result {
     val cls = ct.runtimeClass
     if (classOf[LazyMultibandRaster] isAssignableFrom cls)
       Valid(res.asInstanceOf[T])
-    else if (classOf[MultibandTile] isAssignableFrom cls)
+    else if (classOf[ProjectedRaster[MultibandTile]] isAssignableFrom cls)
       Valid(res.evaluateDouble.asInstanceOf[T])
+    else if (classOf[MultibandTile] isAssignableFrom cls)
+      Valid(res.evaluateDouble.tile.asInstanceOf[T])
     else
       Invalid(NEL.of(DivergingTypes(cls.getName, List("img"))))
   }

--- a/jvm/src/main/scala/eval/Result.scala
+++ b/jvm/src/main/scala/eval/Result.scala
@@ -64,7 +64,7 @@ case class ImageResult(res: LazyMultibandRaster) extends Result {
     else if (classOf[ProjectedRaster[MultibandTile]] isAssignableFrom cls)
       Valid(res.evaluateDouble.asInstanceOf[T])
     else if (classOf[MultibandTile] isAssignableFrom cls)
-      Valid(res.evaluateDouble.tile.asInstanceOf[T])
+      Valid(res.evaluateDouble.raster.tile.asInstanceOf[T])
     else
       Invalid(NEL.of(DivergingTypes(cls.getName, List("img"))))
   }

--- a/jvm/src/main/scala/eval/ScopedInterpreter.scala
+++ b/jvm/src/main/scala/eval/ScopedInterpreter.scala
@@ -10,21 +10,23 @@ import cats.data.{NonEmptyList => NEL, _}
 import geotrellis.raster.GridBounds
 
 
-trait ScopedInterpreter[Scope] {
+trait ScopedInterpreter[Scope] extends Interpreter {
   def scopeFor(exp: Expression, previous: Option[Scope]): Scope
   def appendDirective(directive: ScopedDirective[Scope]): ScopedInterpreter[Scope]
   def prependDirective(directive: ScopedDirective[Scope]): ScopedInterpreter[Scope]
   def fallbackDirective: ScopedDirective[Scope]
   def instructions(expression: Expression, children: Seq[Result], scope: Scope): Interpreted[Result]
 
-  def apply(exp: Expression, maybeScope: Option[Scope] = None): Interpreted[Result] = {
-    val currentScope = scopeFor(exp, maybeScope)
-    val children: Interpreted[List[Result]] = exp.children.map({ childTree =>
-      val childScope = scopeFor(childTree, Some(currentScope))
-      apply(childTree, Some(childScope))
-    }).sequence
-
-    children.andThen({ childResult => instructions(exp, childResult, currentScope) })
+  def apply(exp: Expression): Interpreted[Result] = {
+    def eval(exp: Expression, maybeScope: Option[Scope] = None): Interpreted[Result] = {
+      val currentScope = scopeFor(exp, maybeScope)
+      val children: Interpreted[List[Result]] = exp.children.map({ childTree =>
+        val childScope = scopeFor(childTree, Some(currentScope))
+        eval(childTree, Some(childScope))
+      }).sequence
+      children.andThen({ childResult => instructions(exp, childResult, currentScope) })
+    }
+    eval(exp)
   }
 }
 

--- a/jvm/src/main/scala/eval/directive/FocalDirectives.scala
+++ b/jvm/src/main/scala/eval/directive/FocalDirectives.scala
@@ -80,7 +80,7 @@ object FocalDirectives {
       })
   }
 
-  val slope = Directive { case (fm@FocalSlope(_, neighborhood), childResults) =>
+  val slope = Directive { case (fm@FocalSlope(_), childResults) =>
     childResults
       .map({ _.as[LazyMultibandRaster] })
       .toList.sequence
@@ -93,7 +93,8 @@ object FocalDirectives {
           val EQUATOR_METERS = 11320
           1 / (EQUATOR_METERS * math.cos(math.toRadians(middleY)))
         }
-        ImageResult(image.slope(NeighborhoodConversion(neighborhood), None, zfactor, re.cellSize))
+        println(image.slope(None, zfactor, re.cellSize))
+        ImageResult(image.slope(None, zfactor, re.cellSize))
       })
   }
 }

--- a/jvm/src/main/scala/eval/directive/SourceDirectives.scala
+++ b/jvm/src/main/scala/eval/directive/SourceDirectives.scala
@@ -23,8 +23,8 @@ object SourceDirectives {
   val boolLiteral = Directive { case (BoolLit(bool), _) => Valid(BoolResult(bool)) }
 
   val rasterLiteral = Directive {
-    case (RasterLit(r), _) if r.isInstanceOf[Raster[MultibandTile]] =>
-      val mbRaster = r.asInstanceOf[Raster[MultibandTile]]
+    case (RasterLit(r), _) if r.isInstanceOf[ProjectedRaster[MultibandTile]] =>
+      val mbRaster = r.asInstanceOf[ProjectedRaster[MultibandTile]]
       Valid(ImageResult(LazyMultibandRaster(mbRaster)))
     case (RasterLit(r), _) if r.isInstanceOf[LazyMultibandRaster] =>
       val mbRaster = r.asInstanceOf[LazyMultibandRaster]

--- a/jvm/src/main/scala/eval/directive/UnaryDirectives.scala
+++ b/jvm/src/main/scala/eval/directive/UnaryDirectives.scala
@@ -148,14 +148,14 @@ object UnaryDirectives {
   val classification = Directive { case (classify@Classification(_, classMap), childResults) =>
     childResults.head match {
       case ImageResult(lzTile) => Valid(ImageResult(lzTile.classify(BreakMap(classMap.classifications))))
-      case _ => Invalid(NEL.of(NonEvaluableNode(classify, Some("Classification node requires multiband lazytile argument"))))
+      case _ => Invalid(NEL.of(NonEvaluableNode(classify, Some("Classification node requires multiband lazyraster argument"))))
     }
   }
 
   val imageSelection = Directive { case (imgSel@ImageSelect(_, labels), childResults) =>
     childResults.head match {
       case ImageResult(mbLzTile) => Valid(ImageResult(mbLzTile.select(labels)))
-      case _ => Invalid(NEL.of(NonEvaluableNode(imgSel, Some("ImageSelect node requires multiband lazytile argument"))))
+      case _ => Invalid(NEL.of(NonEvaluableNode(imgSel, Some("ImageSelect node requires multiband lazyraster argument"))))
     }
   }
 }

--- a/jvm/src/main/scala/eval/tile/Classify.scala
+++ b/jvm/src/main/scala/eval/tile/Classify.scala
@@ -3,7 +3,7 @@ package com.azavea.maml.eval.tile
 import geotrellis.raster._
 
 
-case class Classify(children: List[LazyTile], f: Double => Int) extends LazyTile.UnaryBranch {
+case class Classify(children: List[LazyRaster], f: Double => Int) extends LazyRaster.UnaryBranch {
   def get(col: Int, row: Int) = f(fst.getDouble(col, row))
   def getDouble(col: Int, row: Int) = i2d(get(col, row))
 }

--- a/jvm/src/main/scala/eval/tile/LazyMultibandRaster.scala
+++ b/jvm/src/main/scala/eval/tile/LazyMultibandRaster.scala
@@ -69,12 +69,11 @@ case class LazyMultibandRaster(val bands: Map[String, LazyRaster]) {
   }
 
   def slope(
-    neighborhood: Neighborhood,
     gridbounds: Option[GridBounds],
     zFactor: Double,
     cs: CellSize
   ): LazyMultibandRaster = {
-    val lztiles = bands.mapValues({ lt => LazyRaster.Slope(List(lt), neighborhood, gridbounds, zFactor, cs) })
+    val lztiles = bands.mapValues({ lt => LazyRaster.Slope(List(lt), gridbounds, zFactor, cs) })
     LazyMultibandRaster(lztiles)
   }
 }

--- a/jvm/src/main/scala/eval/tile/LazyMultibandRaster.scala
+++ b/jvm/src/main/scala/eval/tile/LazyMultibandRaster.scala
@@ -6,6 +6,7 @@ import geotrellis.raster._
 import geotrellis.raster.mapalgebra.local._
 import geotrellis.raster.mapalgebra.focal.{ Neighborhood, TargetCell }
 import geotrellis.raster.render._
+import geotrellis.proj4.CRS
 import geotrellis.vector.{ Extent, MultiPolygon, Point }
 import cats._
 import cats.data._
@@ -17,7 +18,11 @@ import spire.syntax.cfor._
 import scala.reflect.ClassTag
 
 
-case class LazyMultibandRaster(val bands: Map[String, LazyTile]) {
+case class LazyMultibandRaster(val bands: Map[String, LazyRaster]) {
+  assert(
+    Set(bands.values.map(_.crs)).size == 1,
+    s"All raster data must have the same projection. Found: ${bands.values.mkString("; ")}"
+  )
   def select(labels: List[String]): LazyMultibandRaster = {
     val keyOrder = labels.zipWithIndex.toMap
     val selected = bands.filterKeys { labels contains _ }
@@ -27,13 +32,17 @@ case class LazyMultibandRaster(val bands: Map[String, LazyTile]) {
     LazyMultibandRaster(reordered)
   }
 
-  def evaluateAs(ct: CellType): MultibandTile =
-    MultibandTile(bands.values.map(_.evaluateAs(ct)))
+  def crs = bands.values.head.crs
 
-  def evaluate: MultibandTile =
+  def rasterExtent = bands.values.head.rasterExtent
+
+  def evaluateAs(ct: CellType): ProjectedRaster[MultibandTile] =
+    ProjectedRaster(MultibandTile(bands.values.map(_.evaluateAs(ct))), rasterExtent.extent, crs)
+
+  def evaluate: ProjectedRaster[MultibandTile] =
     evaluateAs(IntConstantNoDataCellType)
 
-  def evaluateDouble: MultibandTile =
+  def evaluateDouble: ProjectedRaster[MultibandTile] =
     evaluateAs(DoubleConstantNoDataCellType)
 
   def dualCombine(
@@ -42,29 +51,45 @@ case class LazyMultibandRaster(val bands: Map[String, LazyTile]) {
     g: (Double, Double) => Double
   ): LazyMultibandRaster = {
     val newBands = bands.values.zip(other.bands.values).map { case (v1, v2) =>
-      LazyTile.DualCombine(List(v1, v2), f, g)
+      LazyRaster.DualCombine(List(v1, v2), f, g)
     }.toList
     LazyMultibandRaster(newBands)
   }
 
   def dualMap(f: Int => Int, g: Double => Double): LazyMultibandRaster =
-    LazyMultibandRaster(bands.mapValues({ lt => LazyTile.DualMap(List(lt), f, g) }))
+    LazyMultibandRaster(bands.mapValues({ lt => LazyRaster.DualMap(List(lt), f, g) }))
 
   def focal(
     neighborhood: Neighborhood,
     gridbounds: Option[GridBounds],
     focalFn: (Tile, Neighborhood, Option[GridBounds], TargetCell) => Tile
   ): LazyMultibandRaster = {
-    val lztiles = bands.mapValues({ lt => LazyTile.Focal(List(lt), neighborhood, gridbounds, focalFn) })
+    val lztiles = bands.mapValues({ lt => LazyRaster.Focal(List(lt), neighborhood, gridbounds, focalFn) })
+    LazyMultibandRaster(lztiles)
+  }
+
+  def slope(
+    neighborhood: Neighborhood,
+    gridbounds: Option[GridBounds],
+    zFactor: Double,
+    cs: CellSize
+  ): LazyMultibandRaster = {
+    val lztiles = bands.mapValues({ lt => LazyRaster.Slope(List(lt), neighborhood, gridbounds, zFactor, cs) })
     LazyMultibandRaster(lztiles)
   }
 }
 
 object LazyMultibandRaster {
-  def apply(lazytiles: List[LazyTile]): LazyMultibandRaster = {
-    val defaultLabels = lazytiles.zipWithIndex.map(lt => lt._2.toString -> lt._1).toMap
+  def apply(lazyrasters: List[LazyRaster]): LazyMultibandRaster = {
+    val defaultLabels = lazyrasters.zipWithIndex.map(lt => lt._2.toString -> lt._1).toMap
     LazyMultibandRaster(defaultLabels)
   }
-  def apply(mbRaster: Raster[MultibandTile]): LazyMultibandRaster =
-    LazyMultibandRaster(mbRaster.tile.bands.map(LazyTile(_, mbRaster.extent)).toList)
+  def apply(mbRaster: Raster[MultibandTile], crs: CRS): LazyMultibandRaster =
+    LazyMultibandRaster(mbRaster.tile.bands.map(LazyRaster(_, mbRaster.extent, crs)).toList)
+
+  def apply(projRaster: ProjectedRaster[MultibandTile]): LazyMultibandRaster = {
+    val mbRaster = projRaster.raster
+    LazyMultibandRaster(mbRaster.tile.bands.map(LazyRaster(_, mbRaster.extent, projRaster.crs)).toList)
+
+  }
 }

--- a/jvm/src/main/scala/eval/tile/LazyRaster.scala
+++ b/jvm/src/main/scala/eval/tile/LazyRaster.scala
@@ -4,7 +4,7 @@ import com.azavea.maml.eval._
 
 import geotrellis.raster._
 import geotrellis.raster.mapalgebra.local._
-import geotrellis.raster.mapalgebra.focal.{Neighborhood, TargetCell, Slope => FocalSlope}
+import geotrellis.raster.mapalgebra.focal.{Square, Neighborhood, TargetCell, Slope => GTFocalSlope}
 import geotrellis.raster.render._
 import geotrellis.vector.{Extent, MultiPolygon, Point}
 import geotrellis.proj4.CRS
@@ -169,15 +169,14 @@ object LazyRaster {
 
   case class Slope(
     children: List[LazyRaster],
-    neighborhood: Neighborhood,
     gridbounds: Option[GridBounds],
     zFactor: Double,
     cs: CellSize
   ) extends UnaryBranch {
     override lazy val cols: Int = gridbounds.map(_.width).getOrElse(fst.cols)
     override lazy val rows: Int = gridbounds.map(_.height).getOrElse(fst.rows)
-    lazy val intTile = FocalSlope(fst.evaluate, neighborhood, gridbounds, cs, zFactor, TargetCell.All)
-    lazy val dblTile = FocalSlope(fst.evaluateDouble, neighborhood, gridbounds, cs, zFactor, TargetCell.All)
+    lazy val intTile = GTFocalSlope(fst.evaluate, Square(1), gridbounds, cs, zFactor, TargetCell.All)
+    lazy val dblTile = GTFocalSlope(fst.evaluateDouble, Square(1),  gridbounds, cs, zFactor, TargetCell.All)
 
     def get(col: Int, row: Int) = intTile.get(col, row)
     def getDouble(col: Int, row: Int) = dblTile.get(col, row)

--- a/jvm/src/main/scala/eval/tile/LazyRaster.scala
+++ b/jvm/src/main/scala/eval/tile/LazyRaster.scala
@@ -4,9 +4,10 @@ import com.azavea.maml.eval._
 
 import geotrellis.raster._
 import geotrellis.raster.mapalgebra.local._
-import geotrellis.raster.mapalgebra.focal.{ Neighborhood, TargetCell }
+import geotrellis.raster.mapalgebra.focal.{Neighborhood, TargetCell, Slope => FocalSlope}
 import geotrellis.raster.render._
-import geotrellis.vector.{ Extent, MultiPolygon, Point }
+import geotrellis.vector.{Extent, MultiPolygon, Point}
+import geotrellis.proj4.CRS
 import cats._
 import cats.data._
 import cats.data.Validated._
@@ -17,16 +18,17 @@ import spire.syntax.cfor._
 import scala.reflect.ClassTag
 
 
-sealed trait LazyTile {
-  // TODO: We need to find a way to rip RasterExtent out of LazyTile
+sealed trait LazyRaster {
+  // TODO: We need to find a way to rip RasterExtent out of LazyRaster
   //       while still being able to provide it to Masking operations.
   //       Is this a use case for futo or paramorphisms?
-  def extent: RasterExtent
-  def children: List[LazyTile]
+  def rasterExtent: RasterExtent
+  def children: List[LazyRaster]
   def cols: Int
   def rows: Int
   def get(col: Int, row: Int): Int
   def getDouble(col: Int, row: Int): Double
+  def crs: CRS
 
   def evaluateAs(ct: CellType): Tile = {
     val mutableOutput = ArrayTile.empty(ct, cols, rows)
@@ -52,16 +54,19 @@ sealed trait LazyTile {
 
 }
 
-object LazyTile {
+object LazyRaster {
 
-  def apply(tile: Tile, extent: Extent): LazyTile = Bound(tile, RasterExtent(extent, tile))
+  def apply(tile: Tile, extent: Extent, crs: CRS): LazyRaster =
+    Bound(tile, RasterExtent(extent, tile), crs)
 
-  def apply(tile: Tile, rasterExtent: RasterExtent): LazyTile = Bound(tile, rasterExtent)
+  def apply(tile: Tile, rasterExtent: RasterExtent, crs: CRS): LazyRaster =
+    Bound(tile, rasterExtent, crs)
 
-  def apply(raster: Raster[Tile]): LazyTile = Bound(raster.tile, raster.rasterExtent)
+  def apply(raster: Raster[Tile], crs: CRS): LazyRaster =
+    Bound(raster.tile, raster.rasterExtent, crs)
 
-  /** An LazyTile.Tree has a left and right. The terminal node will have Nil on the left and right */
-  trait Branch extends LazyTile {
+  /** A LazyRaster.Tree has a left and right. */
+  trait Branch extends LazyRaster {
     lazy val cols = {
       val colList = children.map(_.cols).distinct
       // This require block breaks things when there's an imbalance of focal operations on the children
@@ -80,7 +85,8 @@ object LazyTile {
     val arity = 1
     require(children.length == arity, s"Incorrect arity: $arity argument(s) expected, ${children.length} found")
     def fst = children.head
-    def extent: RasterExtent = fst.extent
+    def rasterExtent: RasterExtent = fst.rasterExtent
+    def crs = fst.crs
   }
 
   trait BinaryBranch extends Branch {
@@ -88,16 +94,16 @@ object LazyTile {
     require(children.length == arity, s"Incorrect arity: $arity argument(s) expected, ${children.length} found")
     def fst = children(0)
     def snd = children(1)
-    def extent: RasterExtent = fst.extent combine snd.extent
+    def rasterExtent: RasterExtent = fst.rasterExtent combine snd.rasterExtent
+    def crs = fst.crs
   }
 
-  trait Terminal extends LazyTile {
-    def children: List[LazyTile]
+  trait Terminal extends LazyRaster {
+    def children: List[LazyRaster] = List.empty
   }
 
   /** This object represents tile data sources */
-  case class Bound(tile: Tile, extent: RasterExtent) extends Terminal {
-    def children: List[LazyTile] = List.empty
+  case class Bound(tile: Tile, rasterExtent: RasterExtent, crs: CRS) extends Terminal {
     def cols: Int = tile.cols
     def rows: Int = tile.rows
     def get(col: Int, row: Int): Int = tile.get(col,row)
@@ -105,49 +111,49 @@ object LazyTile {
   }
 
   /* --- Mapping --- */
-  case class MapInt(children: List[LazyTile], f: Int => Int) extends UnaryBranch {
+  case class MapInt(children: List[LazyRaster], f: Int => Int) extends UnaryBranch {
     def get(col: Int, row: Int) = f(fst.get(col, row))
     def getDouble(col: Int, row: Int) = i2d(fst.get(col, row))
   }
 
-  case class MapDouble(children: List[LazyTile], f: Double => Double) extends UnaryBranch {
+  case class MapDouble(children: List[LazyRaster], f: Double => Double) extends UnaryBranch {
     def get(col: Int, row: Int) = d2i(f(fst.getDouble(col, row)))
     def getDouble(col: Int, row: Int) = f(fst.getDouble(col, row))
   }
 
-  case class DualMap(children: List[LazyTile], f: Int => Int, g: Double => Double) extends UnaryBranch {
+  case class DualMap(children: List[LazyRaster], f: Int => Int, g: Double => Double) extends UnaryBranch {
     def get(col: Int, row: Int) = f(fst.get(col, row))
     def getDouble(col: Int, row: Int) = g(fst.getDouble(col, row))
   }
 
   /* --- Combining --- */
-  case class CombineInt(children: List[LazyTile], f: (Int, Int) => Int) extends BinaryBranch {
+  case class CombineInt(children: List[LazyRaster], f: (Int, Int) => Int) extends BinaryBranch {
     def get(col: Int, row: Int) = f(fst.get(col, row), snd.get(col, row))
     def getDouble(col: Int, row: Int) = i2d(f(fst.get(col, row), snd.get(col, row)))
   }
 
-  case class CombineDouble(children: List[LazyTile], f: (Double, Double) => Double) extends BinaryBranch {
+  case class CombineDouble(children: List[LazyRaster], f: (Double, Double) => Double) extends BinaryBranch {
     def get(col: Int, row: Int) = d2i(f(fst.getDouble(col, row), snd.getDouble(col, row)))
     def getDouble(col: Int, row: Int) = f(fst.getDouble(col, row), snd.getDouble(col, row))
   }
 
-  case class DualCombine(children: List[LazyTile], f: (Int, Int) => Int, g: (Double, Double) => Double) extends BinaryBranch {
+  case class DualCombine(children: List[LazyRaster], f: (Int, Int) => Int, g: (Double, Double) => Double) extends BinaryBranch {
     def get(col: Int, row: Int) = f(fst.get(col, row), snd.get(col, row))
     def getDouble(col: Int, row: Int) = g(fst.getDouble(col, row), snd.getDouble(col, row))
   }
 
-  case class TileCombineInt(children: List[LazyTile], scalar: Int, f: (Int, Int) => Int) extends UnaryBranch {
+  case class RasterCombineInt(children: List[LazyRaster], scalar: Int, f: (Int, Int) => Int) extends UnaryBranch {
     def get(col: Int, row: Int) = f(fst.get(col, row), scalar)
     def getDouble(col: Int, row: Int) = i2d(get(col, row))
   }
 
-  case class TileCombineDouble(children: List[LazyTile], scalar: Double, f: (Double, Double) => Double) extends UnaryBranch {
+  case class RasterCombineDouble(children: List[LazyRaster], scalar: Double, f: (Double, Double) => Double) extends UnaryBranch {
     def get(col: Int, row: Int) = d2i(getDouble(col, row))
     def getDouble(col: Int, row: Int) = f(fst.getDouble(col, row), scalar)
   }
 
   case class Focal(
-    children: List[LazyTile],
+    children: List[LazyRaster],
     neighborhood: Neighborhood,
     gridbounds: Option[GridBounds],
     focalFn: (Tile, Neighborhood, Option[GridBounds], TargetCell) => Tile
@@ -156,6 +162,22 @@ object LazyTile {
     override lazy val rows: Int = gridbounds.map(_.height).getOrElse(fst.rows)
     lazy val intTile = focalFn(fst.evaluate, neighborhood, gridbounds, TargetCell.All)
     lazy val dblTile = focalFn(fst.evaluateDouble, neighborhood, gridbounds, TargetCell.All)
+
+    def get(col: Int, row: Int) = intTile.get(col, row)
+    def getDouble(col: Int, row: Int) = dblTile.get(col, row)
+  }
+
+  case class Slope(
+    children: List[LazyRaster],
+    neighborhood: Neighborhood,
+    gridbounds: Option[GridBounds],
+    zFactor: Double,
+    cs: CellSize
+  ) extends UnaryBranch {
+    override lazy val cols: Int = gridbounds.map(_.width).getOrElse(fst.cols)
+    override lazy val rows: Int = gridbounds.map(_.height).getOrElse(fst.rows)
+    lazy val intTile = FocalSlope(fst.evaluate, neighborhood, gridbounds, cs, zFactor, TargetCell.All)
+    lazy val dblTile = FocalSlope(fst.evaluateDouble, neighborhood, gridbounds, cs, zFactor, TargetCell.All)
 
     def get(col: Int, row: Int) = intTile.get(col, row)
     def getDouble(col: Int, row: Int) = dblTile.get(col, row)

--- a/jvm/src/main/scala/eval/tile/Masking.scala
+++ b/jvm/src/main/scala/eval/tile/Masking.scala
@@ -9,11 +9,11 @@ import geotrellis.vector.{ Extent, MultiPolygon, Point }
 import spire.syntax.cfor._
 
 
-case class MaskingNode(children: List[LazyTile], mask: MultiPolygon) extends LazyTile.UnaryBranch {
+case class MaskingNode(children: List[LazyRaster], mask: MultiPolygon) extends LazyRaster.UnaryBranch {
   lazy val cellMask: Tile = {
     val masky = ArrayTile.empty(BitCellType, this.cols, this.rows)
 
-    extent
+    rasterExtent
       .foreach(mask)({ (col, row) => masky.set(col, row, 1) })
 
     masky

--- a/jvm/src/test/scala/eval/EvaluationSpec.scala
+++ b/jvm/src/test/scala/eval/EvaluationSpec.scala
@@ -188,7 +188,7 @@ class EvaluationSpec extends FunSpec with Matchers with ExpressionTreeCodec {
       case Valid(t) => t.bands.head.get(0, 0) should be (1)
       case i@Invalid(_) => fail(s"$i")
     }
-    interpreter(FocalSlope(List(IntArrayTile(1 to 100 toArray, 10, 10)), Square(1))).as[MultibandTile] match {
+    interpreter(FocalSlope(List(IntArrayTile(1 to 100 toArray, 10, 10)))).as[MultibandTile] match {
       case Valid(t) => t.bands.head.get(5, 5) should be (10)
       case i@Invalid(_) => fail(s"$i")
     }

--- a/jvm/src/test/scala/eval/EvaluationSpec.scala
+++ b/jvm/src/test/scala/eval/EvaluationSpec.scala
@@ -8,11 +8,13 @@ import com.azavea.maml.eval.tile._
 import com.azavea.maml.eval.directive.SourceDirectives._
 import com.azavea.maml.eval.directive.OpDirectives._
 import com.azavea.maml.ast.codec.tree.ExpressionTreeCodec
+import com.azavea.maml.util.Square
 
 import io.circe._
 import io.circe.syntax._
 import geotrellis.raster._
 import geotrellis.vector._
+import geotrellis.proj4.WebMercator
 import cats._
 import cats.data.{NonEmptyList => NEL, _}
 import Validated._
@@ -23,7 +25,8 @@ import scala.reflect._
 
 class EvaluationSpec extends FunSpec with Matchers with ExpressionTreeCodec {
 
-  implicit def tileIsTileLiteral(tile: Tile): Expression = RasterLit(Raster(MultibandTile(tile), Extent(0, 0, 0, 0)))
+  implicit def tileIsTileLiteral(tile: Tile): RasterLit[ProjectedRaster[MultibandTile]] =
+    RasterLit(ProjectedRaster(MultibandTile(tile), Extent(0, 0, 0.05, 0.05), WebMercator))
 
   implicit class TypeRefinement(self: Interpreted[Result]) {
     def as[T: ClassTag]: Interpreted[T] = self match {
@@ -32,7 +35,7 @@ class EvaluationSpec extends FunSpec with Matchers with ExpressionTreeCodec {
     }
   }
 
-  val interpreter = NaiveInterpreter.DEFAULT
+  val interpreter = Interpreter.DEFAULT
 
   it("Should interpret and evaluate to Boolean literals") {
     interpreter(BoolLit(true)).as[Boolean] should be (Valid(true))
@@ -183,6 +186,10 @@ class EvaluationSpec extends FunSpec with Matchers with ExpressionTreeCodec {
     }
     interpreter(IntArrayTile(1 to 4 toArray, 2, 2) > IntArrayTile(0 to 3 toArray, 2, 2)).as[MultibandTile] match {
       case Valid(t) => t.bands.head.get(0, 0) should be (1)
+      case i@Invalid(_) => fail(s"$i")
+    }
+    interpreter(FocalSlope(List(IntArrayTile(1 to 100 toArray, 10, 10)), Square(1))).as[MultibandTile] match {
+      case Valid(t) => t.bands.head.get(5, 5) should be (10)
       case i@Invalid(_) => fail(s"$i")
     }
   }

--- a/jvm/src/test/scala/eval/MultibandSelectionSpec.scala
+++ b/jvm/src/test/scala/eval/MultibandSelectionSpec.scala
@@ -4,6 +4,7 @@ import com.azavea.maml.ast._
 import com.azavea.maml.eval.tile._
 import geotrellis.raster._
 import geotrellis.vector._
+import geotrellis.proj4.WebMercator
 
 import org.scalatest._
 
@@ -13,7 +14,7 @@ class MultibandSelectionSpec extends FunSpec with Matchers {
   def someRaster(v: Int) = {
     val someTile = ArrayTile(Array(v, v, v, v), 2, 2)
     val someExtent = Extent(0, 0, 1, 1)
-    LazyTile(someTile, someExtent)
+    LazyRaster(someTile, someExtent, WebMercator)
   }
 
   it("Should allow for the selection of bands by idx") {

--- a/jvm/src/test/scala/eval/ScopedEvaluationSpec.scala
+++ b/jvm/src/test/scala/eval/ScopedEvaluationSpec.scala
@@ -10,6 +10,7 @@ import com.azavea.maml.eval.directive._
 
 import geotrellis.raster._
 import geotrellis.vector._
+import geotrellis.proj4.WebMercator
 import cats._
 import cats.data.{NonEmptyList => NEL, _}
 import Validated._
@@ -19,8 +20,8 @@ import scala.reflect._
 
 class ScopedEvaluationSpec extends FunSpec with Matchers {
 
-  def tileToLit(tile: Tile): RasterLit[Raster[MultibandTile]] =
-    RasterLit(Raster(MultibandTile(tile), Extent(0, 0, 0, 0)))
+  def tileToLit(tile: Tile): RasterLit[ProjectedRaster[MultibandTile]] =
+    RasterLit(ProjectedRaster(MultibandTile(tile), Extent(0, 0, 0, 0), WebMercator))
 
   implicit class TypeRefinement(self: Interpreted[Result]) {
     def as[T](implicit ct: ClassTag[T]): Interpreted[T] = self match {

--- a/shared/src/main/scala/ast/Expression.scala
+++ b/shared/src/main/scala/ast/Expression.scala
@@ -292,7 +292,8 @@ case class FocalStdDev(children: List[Expression], neighborhood: Neighborhood) e
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
-case class FocalSlope(children: List[Expression], neighborhood: Neighborhood) extends Expression("fslope") with FocalExpression {
+case class FocalSlope(children: List[Expression]) extends Expression("fslope") with FocalExpression {
+  def neighborhood = Square(1)
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 

--- a/shared/src/main/scala/ast/Expression.scala
+++ b/shared/src/main/scala/ast/Expression.scala
@@ -292,6 +292,10 @@ case class FocalStdDev(children: List[Expression], neighborhood: Neighborhood) e
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
+case class FocalSlope(children: List[Expression], neighborhood: Neighborhood) extends Expression("fslope") with FocalExpression {
+  def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
+}
+
 case class ImageSelect(children: List[Expression], labels: List[String]) extends Expression("sel") with UnaryExpression {
   val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.imageOnly
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)

--- a/shared/src/main/scala/ast/codec/MamlCodecInstances.scala
+++ b/shared/src/main/scala/ast/codec/MamlCodecInstances.scala
@@ -95,6 +95,11 @@ trait MamlCodecInstances extends MamlUtilityCodecs {
   implicit lazy val encodeFocalStdDev: Encoder[FocalStdDev] =
     Encoder.forProduct3("args", "neighborhood", "symbol")(u => (u.children, u.neighborhood, u.sym))
 
+  implicit lazy val decodeFocalSlope: Decoder[FocalSlope] =
+    Decoder.forProduct2("args", "neighborhood")(FocalSlope.apply)
+  implicit lazy val encodeFocalSlope: Encoder[FocalSlope] =
+    Encoder.forProduct3("args", "neighborhood", "symbol")(u => (u.children, u.neighborhood, u.sym))
+
   implicit lazy val decodeGreater: Decoder[Greater] =
     Decoder.forProduct1("args"){ args: List[Expression] => Greater(args) }
   implicit lazy val encodeGreater: Encoder[Greater] =

--- a/shared/src/main/scala/ast/codec/MamlCodecInstances.scala
+++ b/shared/src/main/scala/ast/codec/MamlCodecInstances.scala
@@ -96,9 +96,9 @@ trait MamlCodecInstances extends MamlUtilityCodecs {
     Encoder.forProduct3("args", "neighborhood", "symbol")(u => (u.children, u.neighborhood, u.sym))
 
   implicit lazy val decodeFocalSlope: Decoder[FocalSlope] =
-    Decoder.forProduct2("args", "neighborhood")(FocalSlope.apply)
+    Decoder.forProduct1("args")(FocalSlope.apply)
   implicit lazy val encodeFocalSlope: Encoder[FocalSlope] =
-    Encoder.forProduct3("args", "neighborhood", "symbol")(u => (u.children, u.neighborhood, u.sym))
+    Encoder.forProduct2("args", "symbol")(u => (u.children, u.sym))
 
   implicit lazy val decodeGreater: Decoder[Greater] =
     Decoder.forProduct1("args"){ args: List[Expression] => Greater(args) }

--- a/shared/src/main/scala/ast/codec/tree/ExpressionTreeCodec.scala
+++ b/shared/src/main/scala/ast/codec/tree/ExpressionTreeCodec.scala
@@ -41,6 +41,8 @@ trait ExpressionTreeCodec extends MamlCodecInstances {
     case fmode @ FocalMode(_, _) => fmode.asJson
     case fsum @ FocalSum(_, _) => fsum.asJson
     case fstddev @ FocalStdDev(_, _) => fstddev.asJson
+    case fslope @ FocalSlope(_, _) => fslope.asJson
+    case imgsel @ ImageSelect(_, _) => imgsel.asJson
     case lneg @ LogicalNegation(_) => lneg.asJson
     case nneg @ NumericNegation(_) => nneg.asJson
     case udfn @ Undefined(_) => udfn.asJson
@@ -124,6 +126,8 @@ trait ExpressionTreeCodec extends MamlCodecInstances {
       case "fmode" => Decoder[FocalMode]
       case "fsum" => Decoder[FocalSum]
       case "fstddev" => Decoder[FocalStdDev]
+      case "fslope" => Decoder[FocalSlope]
+      case "sel" => Decoder[ImageSelect]
       case "int" => Decoder[IntLit]
       case "intV" => Decoder[IntVar]
       case "dbl" => Decoder[DblLit]

--- a/shared/src/main/scala/ast/codec/tree/ExpressionTreeCodec.scala
+++ b/shared/src/main/scala/ast/codec/tree/ExpressionTreeCodec.scala
@@ -41,7 +41,7 @@ trait ExpressionTreeCodec extends MamlCodecInstances {
     case fmode @ FocalMode(_, _) => fmode.asJson
     case fsum @ FocalSum(_, _) => fsum.asJson
     case fstddev @ FocalStdDev(_, _) => fstddev.asJson
-    case fslope @ FocalSlope(_, _) => fslope.asJson
+    case fslope @ FocalSlope(_) => fslope.asJson
     case imgsel @ ImageSelect(_, _) => imgsel.asJson
     case lneg @ LogicalNegation(_) => lneg.asJson
     case nneg @ NumericNegation(_) => nneg.asJson


### PR DESCRIPTION
This PR adds the ability to specify slope calculation as part of a MAML program. Other focal operations have already been added, but this operation requires deeper changes than those did: in addition to the implicit information encoded by the grid structure of tiles which is sufficient for the bulk of map algebra operations and the explicit extent mapping required by masking, slope requires a mapping from the approximate latitude at some location to some "z-factor" which is a coefficient necessary to determine with precision the 'rise' in a slope calculation's "rise over run".

This means that `LazyRaster` instances now expect a full `ProjectedMultibandRaster` instead of a simple `MultibandRaster` or - before that - `MultibandTile`.