### PR TITLE
Upgrade circe version to 0.11.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,9 @@ lazy val root = project.in(file("."))
     licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
   ).enablePlugins(ScalaJSPlugin)
 
-val circeVer = "0.10.0"
-val gtVer    = "2.2.0"
+val circeVer       = "0.11.1"
+val circeOpticsVer = "0.11.0"
+val gtVer          = "2.2.0"
 
 lazy val maml = crossProject.in(file("."))
   .settings(publishSettings:_*)
@@ -25,7 +26,7 @@ lazy val maml = crossProject.in(file("."))
       "io.circe"                   %% "circe-generic"        % circeVer,
       "io.circe"                   %% "circe-generic-extras" % circeVer,
       "io.circe"                   %% "circe-parser"         % circeVer,
-      "io.circe"                   %% "circe-optics"         % circeVer
+      "io.circe"                   %% "circe-optics"         % circeOpticsVer
     )
   ).jvmSettings(
     name := "maml-jvm",


### PR DESCRIPTION
This commit also separates out `circe-optics` since it is published from a [different repository](https://github.com/circe/circe-optics) as of 0.10.0 (and has not been updated since 0.11.0) - see https://github.com/circe/circe/releases/tag/v0.10.0-M2

Happy to take a different approach to splitting out the circe versions as well.

This change is necessary for a dependency conflict we are running into in Raster Foundry.