### PR TITLE
Use  methods to create key decoders

### DIFF
--- a/shared/src/main/scala/ast/codec/MamlUtilityCodecs.scala
+++ b/shared/src/main/scala/ast/codec/MamlUtilityCodecs.scala
@@ -17,18 +17,18 @@ import scala.util.Try
 
 
 trait MamlUtilityCodecs {
-  implicit val decodeKeyDouble: KeyDecoder[Double] = new KeyDecoder[Double] {
-    final def apply(key: String): Option[Double] = Try(key.toDouble).toOption
+  implicit val decodeKeyDouble: KeyDecoder[Double] = KeyDecoder.instance[Double] {
+    (key: String) => Try(key.toDouble).toOption
   }
-  implicit val encodeKeyDouble: KeyEncoder[Double] = new KeyEncoder[Double] {
-    final def apply(key: Double): String = key.toString
+  implicit val encodeKeyDouble: KeyEncoder[Double] = KeyEncoder.instance[Double] {
+    (key: Double) => key.toString
   }
 
-  implicit val decodeKeyUUID: KeyDecoder[UUID] = new KeyDecoder[UUID] {
-    final def apply(key: String): Option[UUID] = Try(UUID.fromString(key)).toOption
+  implicit val decodeKeyUUID: KeyDecoder[UUID] = KeyDecoder.instance[UUID] {
+    (key: String) => Try(UUID.fromString(key)).toOption
   }
-  implicit val encodeKeyUUID: KeyEncoder[UUID] = new KeyEncoder[UUID] {
-    final def apply(key: UUID): String = key.toString
+  implicit val encodeKeyUUID: KeyEncoder[UUID] = KeyEncoder.instance[UUID] {
+    (key: UUID) => key.toString
   }
 
   implicit lazy val classBoundaryDecoder: Decoder[ClassBoundaryType] =


### PR DESCRIPTION
This absolutely baffling error appeared downstream after bumping to circe 0.11: `java.lang.IncompatibleClassChangeError: class com.azavea.maml.ast.codec.MamlUtilityCodecs$$anon$1 has interface io.circe.KeyDecoder as super class`... The changes introduced in this PR are an attempt to address that issue by avoiding the manual construction of trait instances and delegating that work to some circe helper functions.

It is unclear why this should work, but it appears to do the trick.