### PR TITLE
Add MaskingNodes for different types of tiles

### DIFF
--- a/jvm/src/main/scala/eval/directive/OpDirectives.scala
+++ b/jvm/src/main/scala/eval/directive/OpDirectives.scala
@@ -361,11 +361,11 @@ object OpDirectives {
       val bandList = lzRaster.bands.values.toList
       (geom.as[MultiPolygon], bandList.length) match {
         case (Some(mp), 1) =>
-          Valid(ImageResult(LazyMultibandRaster(List(SingleBandMaskingNode(bandList, mp)))))
+          Valid(ImageResult(LazyMultibandRaster(SingleBandMaskingNode(bandList, mp).bands)))
         case (Some(mp), 3) =>
-          Valid(ImageResult(LazyMultibandRaster(List(RGBMaskingNode(bandList, mp)))))
+          Valid(ImageResult(LazyMultibandRaster(RGBMaskingNode(bandList, mp).bands)))
         case (Some(mp), 4) =>
-          Valid(ImageResult(LazyMultibandRaster(List(RGBAMaskingNode(bandList, mp)))))
+          Valid(ImageResult(LazyMultibandRaster(RGBAMaskingNode(bandList, mp).bands)))
         case (Some(_), n) =>
               Invalid(
                 NEL.of(

--- a/jvm/src/main/scala/eval/tile/LazyRaster.scala
+++ b/jvm/src/main/scala/eval/tile/LazyRaster.scala
@@ -99,6 +99,27 @@ object LazyRaster {
     def crs = fst.crs
   }
 
+  trait TernaryBranch extends Branch {
+    val arity = 3
+    require(children.length == arity, s"Incorrect arity: $arity argument(s) expected, ${children.length} found")
+    def fst = children(0)
+    def snd = children(1)
+    def thd = children(2)
+    def rasterExtent: RasterExtent = fst.rasterExtent combine snd.rasterExtent combine thd.rasterExtent
+    def crs = fst.crs
+  }
+
+  trait QuaternaryBranch extends Branch {
+    val arity = 4
+    require(children.length == arity, s"Incorrect arity: $arity argument(s) expected, ${children.length} found")
+    def fst = children(0)
+    def snd = children(1)
+    def thd = children(2)
+    def fth = children(3)
+    def rasterExtent: RasterExtent = fst.rasterExtent combine snd.rasterExtent combine thd.rasterExtent combine fth.rasterExtent
+    def crs = fst.crs
+  }
+
   trait Terminal extends LazyRaster {
     def children: List[LazyRaster] = List.empty
   }

--- a/jvm/src/main/scala/eval/tile/Masking.scala
+++ b/jvm/src/main/scala/eval/tile/Masking.scala
@@ -38,6 +38,12 @@ sealed trait MaskingNode extends LazyRaster.Branch {
 
     if (isNoData(v)) v else if (cellMask.get(col, row) == 1) v else Double.NaN
   }
+
+  def bands: List[LazyRaster] = children map {(lzRaster: LazyRaster) =>
+    LazyRaster(lzRaster.evaluateAs(DoubleConstantNoDataCellType).localMask(cellMask, 0, NODATA),
+               rasterExtent,
+               fst.crs)
+  }
 }
 
 case class SingleBandMaskingNode(children: List[LazyRaster], mask: MultiPolygon)

--- a/jvm/src/main/scala/eval/tile/Masking.scala
+++ b/jvm/src/main/scala/eval/tile/Masking.scala
@@ -8,8 +8,13 @@ import geotrellis.raster.render._
 import geotrellis.vector.{ Extent, MultiPolygon, Point }
 import spire.syntax.cfor._
 
+sealed trait MaskingNode extends LazyRaster.Branch {
 
-case class MaskingNode(children: List[LazyRaster], mask: MultiPolygon) extends LazyRaster.UnaryBranch {
+  val children: List[LazyRaster]
+  val mask: MultiPolygon
+
+  def fst: LazyRaster
+
   lazy val cellMask: Tile = {
     val masky = ArrayTile.empty(BitCellType, this.cols, this.rows)
 
@@ -35,3 +40,11 @@ case class MaskingNode(children: List[LazyRaster], mask: MultiPolygon) extends L
   }
 }
 
+case class SingleBandMaskingNode(children: List[LazyRaster], mask: MultiPolygon)
+    extends MaskingNode with LazyRaster.UnaryBranch
+
+case class RGBMaskingNode(children: List[LazyRaster], mask: MultiPolygon)
+    extends MaskingNode with LazyRaster.TernaryBranch
+
+case class RGBAMaskingNode(children: List[LazyRaster], mask: MultiPolygon)
+    extends MaskingNode with LazyRaster.QuaternaryBranch

--- a/jvm/src/test/scala/eval/ResultSpec.scala
+++ b/jvm/src/test/scala/eval/ResultSpec.scala
@@ -60,17 +60,21 @@ class ResultSpec extends FunSpec with Matchers {
   it("Evaluate mask out data according to a mask") {
     val rasterOnes = LazyRaster(IntArrayTile(1 to 16 toArray, 4, 4), Extent(0, 0, 3, 3), WebMercator)
     val mask = Extent(0, 0, 1, 1).as[Polygon].map(MultiPolygon(_)).get
-    val maskResult = ImageResult(LazyMultibandRaster(List(MaskingNode(List(rasterOnes), mask))))
+    val maskResultSB = ImageResult(LazyMultibandRaster(List(SingleBandMaskingNode(List(rasterOnes), mask))))
+    val maskResultRGB = ImageResult(LazyMultibandRaster(List(RGBMaskingNode(List(rasterOnes, rasterOnes, rasterOnes), mask))))
 
     for {
       x <- (0 to 3 toArray)
       y <- (0 to 3 toArray)
     } yield {
-      val fetched = maskResult.res.bands.head._2.get(x, y)
+      val fetchedSB = maskResultSB.res.bands.head._2.get(x, y)
+      val fetchedRGB = maskResultRGB.res.bands map { _._2.get(x, y) }
       if ((x, y) == (0, 3)) {
-        isData(fetched) should be (true)
+        isData(fetchedSB) should be (true)
+        fetchedRGB map { isData(_) } should be (List(true, true, true))
       } else {
-        isData(fetched) should be (false)
+        isData(fetchedSB) should be (false)
+        fetchedRGB map { isData(_) } should be (List(false, false, false))
       }
     }
   }

--- a/jvm/src/test/scala/eval/ResultSpec.scala
+++ b/jvm/src/test/scala/eval/ResultSpec.scala
@@ -61,14 +61,15 @@ class ResultSpec extends FunSpec with Matchers {
     val rasterOnes = LazyRaster(IntArrayTile(1 to 16 toArray, 4, 4), Extent(0, 0, 3, 3), WebMercator)
     val mask = Extent(0, 0, 1, 1).as[Polygon].map(MultiPolygon(_)).get
     val maskResultSB = ImageResult(LazyMultibandRaster(List(SingleBandMaskingNode(List(rasterOnes), mask))))
-    val maskResultRGB = ImageResult(LazyMultibandRaster(List(RGBMaskingNode(List(rasterOnes, rasterOnes, rasterOnes), mask))))
+    val maskResultRGB = ImageResult(LazyMultibandRaster(
+                                      RGBMaskingNode(List(rasterOnes, rasterOnes, rasterOnes), mask).bands))
 
     for {
       x <- (0 to 3 toArray)
       y <- (0 to 3 toArray)
     } yield {
       val fetchedSB = maskResultSB.res.bands.head._2.get(x, y)
-      val fetchedRGB = maskResultRGB.res.bands map { _._2.get(x, y) }
+      val fetchedRGB = maskResultRGB.res.bands.toList map { _._2.get(x, y) }
       if ((x, y) == (0, 3)) {
         isData(fetchedSB) should be (true)
         fetchedRGB map { isData(_) } should be (List(true, true, true))


### PR DESCRIPTION
Overview
-----

This PR turns MaskingNode into an ADT with options for different arities of source data (unary, ternary, quaternary) and adds a failing test where my guess about what should have happened as a result turned out to be wrong.

The reason for this is that we currently can't mask any kind of non-single band imagery result, which is a drag, because in RF for single band viz of mosaics we return a multiband tile of the RGBA channels after rendering, and for multiband viz of mosaics we return an RGB tile.

Testing
-----

- I added a test to `ResultSpec` that shows that evaluation of `MaskingNode`s, even after accounting for the possibility of several source bands, squashes everything down to a single band