### PR TITLE
Use GridExtent[Int]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ lazy val root = project.in(file("."))
 
 val circeVer       = "0.11.1"
 val circeOpticsVer = "0.11.0"
-val gtVer          = "3.0.0-M1-SNAPSHOT"
+val gtVer          = "3.0.1-SNAPSHOT"
 
 lazy val maml = crossProject.in(file("."))
   .settings(publishSettings:_*)

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ lazy val root = project.in(file("."))
 
 val circeVer       = "0.11.1"
 val circeOpticsVer = "0.11.0"
-val gtVer          = "2.2.0"
+val gtVer          = "3.0.0-M1-SNAPSHOT"
 
 lazy val maml = crossProject.in(file("."))
   .settings(publishSettings:_*)

--- a/jvm/src/main/scala/GTHack.scala
+++ b/jvm/src/main/scala/GTHack.scala
@@ -5,7 +5,7 @@ import geotrellis.raster.io.geotiff._
 import geotrellis.raster.io.geotiff.OverviewStrategy
 
 object GTHack {
-  def closestTiffOverview[T <: CellGrid](
+  def closestTiffOverview[T <: CellGrid[Int]](
     tiff: GeoTiff[T],
     cs: CellSize,
     strategy: OverviewStrategy

--- a/jvm/src/main/scala/eval/directive/SourceDirectives.scala
+++ b/jvm/src/main/scala/eval/directive/SourceDirectives.scala
@@ -23,7 +23,7 @@ object SourceDirectives {
   val boolLiteral = Directive { case (BoolLit(bool), _) => Valid(BoolResult(bool)) }
 
   val rasterLiteral = Directive {
-    case (RasterLit(r), _) if r.isInstanceOf[ProjectedRaster[MultibandTile]] =>
+    case (RasterLit(r), _) if r.isInstanceOf[ProjectedRaster[_]] =>
       val mbRaster = r.asInstanceOf[ProjectedRaster[MultibandTile]]
       Valid(ImageResult(LazyMultibandRaster(mbRaster)))
     case (RasterLit(r), _) if r.isInstanceOf[LazyMultibandRaster] =>
@@ -44,4 +44,3 @@ object SourceDirectives {
     }
   }
 }
-

--- a/jvm/src/main/scala/eval/tile/LazyMultibandRaster.scala
+++ b/jvm/src/main/scala/eval/tile/LazyMultibandRaster.scala
@@ -61,15 +61,15 @@ case class LazyMultibandRaster(val bands: Map[String, LazyRaster]) {
 
   def focal(
     neighborhood: Neighborhood,
-    gridbounds: Option[GridBounds],
-    focalFn: (Tile, Neighborhood, Option[GridBounds], TargetCell) => Tile
+    gridbounds: Option[GridBounds[Int]],
+    focalFn: (Tile, Neighborhood, Option[GridBounds[Int]], TargetCell) => Tile
   ): LazyMultibandRaster = {
     val lztiles = bands.mapValues({ lt => LazyRaster.Focal(List(lt), neighborhood, gridbounds, focalFn) })
     LazyMultibandRaster(lztiles)
   }
 
   def slope(
-    gridbounds: Option[GridBounds],
+    gridbounds: Option[GridBounds[Int]],
     zFactor: Double,
     cs: CellSize
   ): LazyMultibandRaster = {
@@ -78,7 +78,7 @@ case class LazyMultibandRaster(val bands: Map[String, LazyRaster]) {
   }
 
   def hillshade(
-    gridbounds: Option[GridBounds],
+    gridbounds: Option[GridBounds[Int]],
     zFactor: Double,
     cs: CellSize,
     azimuth: Double,

--- a/jvm/src/main/scala/eval/tile/LazyRaster.scala
+++ b/jvm/src/main/scala/eval/tile/LazyRaster.scala
@@ -156,8 +156,8 @@ object LazyRaster {
   case class Focal(
     children: List[LazyRaster],
     neighborhood: Neighborhood,
-    gridbounds: Option[GridBounds],
-    focalFn: (Tile, Neighborhood, Option[GridBounds], TargetCell) => Tile
+    gridbounds: Option[GridBounds[Int]],
+    focalFn: (Tile, Neighborhood, Option[GridBounds[Int]], TargetCell) => Tile
   ) extends UnaryBranch {
     override lazy val cols: Int = gridbounds.map(_.width).getOrElse(fst.cols)
     override lazy val rows: Int = gridbounds.map(_.height).getOrElse(fst.rows)
@@ -170,7 +170,7 @@ object LazyRaster {
 
   case class Slope(
     children: List[LazyRaster],
-    gridbounds: Option[GridBounds],
+    gridbounds: Option[GridBounds[Int]],
     zFactor: Double,
     cs: CellSize
   ) extends UnaryBranch {
@@ -185,7 +185,7 @@ object LazyRaster {
 
   case class Hillshade(
     children: List[LazyRaster],
-    gridbounds: Option[GridBounds],
+    gridbounds: Option[GridBounds[Int]],
     zFactor: Double,
     cs: CellSize,
     azimuth: Double,
@@ -203,4 +203,3 @@ object LazyRaster {
     def getDouble(col: Int, row: Int) = dblTile.get(col, row)
   }
 }
-

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.1"
+version in ThisBuild := "0.3.0-SNAPSHOT"


### PR DESCRIPTION
Requires: https://github.com/locationtech/geotrellis/pull/2886

PR to track changes in GeoTrellis `3.0.0-M1-SNAPSHOT`.
Overall mechanical changes to use new shape of `GridExtent`