### PR TITLE
Avoid combining raster extents due to floating point error

### DIFF
--- a/jvm/src/main/scala/eval/tile/LazyRaster.scala
+++ b/jvm/src/main/scala/eval/tile/LazyRaster.scala
@@ -95,7 +95,11 @@ object LazyRaster {
     require(children.length == arity, s"Incorrect arity: $arity argument(s) expected, ${children.length} found")
     def fst = children(0)
     def snd = children(1)
-    def rasterExtent: RasterExtent = fst.rasterExtent combine snd.rasterExtent
+
+    /** rasterExtent.combine(rasterExtent) was formerly used to derive this value. It sometimes has
+     *   issues with floating point arithmetic. Using the first rasterExtent *should* be fine
+    **/
+    def rasterExtent: RasterExtent = fst.rasterExtent
     def crs = fst.crs
   }
 


### PR DESCRIPTION
`RasterExtent.combine` asserts that cellsizes be equal but floating point arithmetic can make this difficult. Extraordinarily close cell sizes end up failing the equality assertion when it would be better to pass over in silence