### PR TITLE
Assume correct extents in binary ops to avoid floating point errors

### DIFF
--- a/jvm/src/main/scala/eval/tile/LazyRaster.scala
+++ b/jvm/src/main/scala/eval/tile/LazyRaster.scala
@@ -95,7 +95,7 @@ object LazyRaster {
     require(children.length == arity, s"Incorrect arity: $arity argument(s) expected, ${children.length} found")
     def fst = children(0)
     def snd = children(1)
-    def rasterExtent: RasterExtent = fst.rasterExtent combine snd.rasterExtent
+    def rasterExtent: RasterExtent = fst.rasterExtent
     def crs = fst.crs
   }
 


### PR DESCRIPTION
Floating point math can lead to situations in which combined `GridExtent`s fail a requirement that checks correspondence between `CellSize`+`Extent` on the one hand and pixel cols/rows on the other. 

This is likely desirable behavior if it happens only when bad data has been passed into MAML. It is very undesirable if it occurs in certain edge cases that are able to compute results properly, as happens whenever the `Extent`/`CellSize` ratio becomes too large and floating point arithmetic's approximations fail us.

The upshot of this is that we get slightly less guarded execution but avoid false positive errors