### PR TITLE
Fix codec spec for 2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add STRTA and migrate to CircleCI [#93](https://github.com/geotrellis/maml/pull/93)
 - Add changelog and pull request template [#96](https://github.com/geotrellis/maml/pull/96)
 
+### Changed
+- Fixed 2.12 compilation in tests [#95](https://github.com/geotrellis/maml/pull/95)
+
 ## [0.3.2] - 2019-04-17
 ### Added
 - Add hillshade [#77](https://github.com/geotrellis/maml/pull/77)

--- a/shared/src/test/scala/ast/codec/tree/MamlExpressionTreeCodecSpec.scala
+++ b/shared/src/test/scala/ast/codec/tree/MamlExpressionTreeCodecSpec.scala
@@ -12,7 +12,7 @@ import org.scalatest._
 import org.scalatest.prop._
 
 
-class ExpressionTreeCodecSpec extends PropSpec with Checkers with LazyLogging {
+class ExpressionTreeCodecSpec extends PropSpec with Checkers with LazyLogging with ExpressionTreeCodec {
   property("bijective serialization on whole tree") {
     check(forAll(Generators.genExpression()) { (ast: Expression) =>
       logger.debug(s"Attempting to encode AST: $ast")


### PR DESCRIPTION
Codec tests were failing in CI. It looks as though the 2.11 -> 2.12 bump included some changes regarding implicit resolution (? this is a bit unclear but does salve for the phenomena). With this PR we should be able to run 2.12 CI as well as 2.11