### PR TITLE
Update CircleCI publishing strategy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,7 @@ workflows:
               only:
                 - master
                 - develop
+                - /release\/.*/
       - "openjdk8-scala2.12.8-nodelts_deploy":
           requires:
             - "openjdk8-scala2.12.8-nodelts"
@@ -83,6 +84,7 @@ workflows:
               only:
                 - master
                 - develop
+                - /release\/.*/
 
 jobs:
   "openjdk8-scala2.11.12-nodelts":

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,7 @@ workflows:
               only:
                 - develop
                 - /release\/.*/
+                - /hotfix\/.*/
       - "openjdk8-scala2.12.8-nodelts_deploy":
           requires:
             - "openjdk8-scala2.12.8-nodelts"
@@ -83,6 +84,7 @@ workflows:
               only:
                 - develop
                 - /release\/.*/
+                - /hotfix\/.*/
 
 jobs:
   "openjdk8-scala2.11.12-nodelts":

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,6 @@ workflows:
                 - /^(.*)$/
             branches:
               only:
-                - master
                 - develop
                 - /release\/.*/
       - "openjdk8-scala2.12.8-nodelts_deploy":
@@ -82,7 +81,6 @@ workflows:
                 - /^(.*)$/
             branches:
               only:
-                - master
                 - develop
                 - /release\/.*/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
+### Changed
+- Update CircleCI publishing strategy [#107](https://github.com/geotrellis/maml/pull/107)
 
 ## [0.4.0] - 2019-05-23
 ### Added


### PR DESCRIPTION
## Overview

- Add `release/*` and `hotfix/*` to `branches` filter to publish artifacts to SNAPSHOT repository so we can test after committing fixes.
- Remove `master` from `branches` filter to stop publishing release artifacts twice (once for `tags`, and once for `branches`).

Resolves #105 

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

## Testing Instructions

See: https://circleci.com/gh/geotrellis/maml/369

There isn't a great way to test the removal of `master` from the `branches` filter without pushing something to `master`.