### PR TITLE
Upgrade to GT 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Update CircleCI publishing strategy [#107](https://github.com/geotrellis/maml/pull/107)
+- Upgrade to GeoTrellis 3.1.0 [#110](https://github.com/geotrellis/maml/pull/110)
 
 ### Fixed
 - Manually create staging repository to define repository ID in state [#109](https://github.com/geotrellis/maml/pull/109)

--- a/build.sbt
+++ b/build.sbt
@@ -92,7 +92,7 @@ lazy val root = project.in(file("."))
 
 val circeVer       = "0.11.1"
 val circeOpticsVer = "0.11.0"
-val gtVer          = "3.0.0-M3"
+val gtVer          = "3.1.0"
 
 lazy val maml = crossProject.in(file("."))
   .settings(commonSettings)
@@ -127,6 +127,18 @@ lazy val mamlSpark = project.in(file("spark"))
       "org.locationtech.geotrellis" %% "geotrellis-spark-testkit" % gtVer % "test",
       "org.apache.spark"            %% "spark-core"               % "2.4.0" % "provided",
       "org.apache.spark"            %% "spark-sql"                % "2.4.0" % "provided"
-    )
-  )
-  .dependsOn(mamlJvm)
+    ),
+  /** https://github.com/lucidworks/spark-solr/issues/179 */
+    dependencyOverrides ++= {
+      val deps = Seq(
+        "com.fasterxml.jackson.core" % "jackson-core" % "2.6.7",
+        "com.fasterxml.jackson.core" % "jackson-databind" % "2.6.7",
+        "com.fasterxml.jackson.core" % "jackson-annotations" % "2.6.7"
+      )
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        // if Scala 2.12+ is used
+        case Some((2, scalaMajor)) if scalaMajor >= 12 => deps
+        case _ => deps :+ "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.6.7"
+      }
+    }
+  ).dependsOn(mamlJvm)

--- a/jvm/src/main/scala/eval/directive/OpDirectives.scala
+++ b/jvm/src/main/scala/eval/directive/OpDirectives.scala
@@ -14,11 +14,16 @@ import Validated._
 import geotrellis.vector._
 import geotrellis.raster.{Tile, isData}
 
+import scala.reflect.ClassTag
 import scala.concurrent.duration._
 import scala.util.Try
 
 
 object OpDirectives {
+
+  private def asInstanceOfOption[T: ClassTag](o: Any): Option[T] = 
+    Some(o) collect { case m: T => m}
+
   private def doubleResults(grouped: Map[MamlKind, Seq[Result]]): Interpreted[List[Double]] =
     grouped.getOrElse(MamlKind.Double, List.empty).map(_.as[Double]).toList.sequence
 
@@ -365,7 +370,7 @@ object OpDirectives {
       case _ =>
         Invalid(NEL.of(NonEvaluableNode(mask, Some("Masking operation requires both a tile and a vector argument"))))
     }).andThen({ case (lzRaster, geom) =>
-      geom.as[MultiPolygon] match {
+      asInstanceOfOption[MultiPolygon](geom) match {
         case Some(mp) =>
           Valid(ImageResult(lzRaster.mask(mp)))
         case None =>

--- a/jvm/src/main/scala/eval/directive/SourceDirectives.scala
+++ b/jvm/src/main/scala/eval/directive/SourceDirectives.scala
@@ -7,9 +7,12 @@ import com.azavea.maml.ast._
 
 import io.circe._
 import io.circe.parser._
+
 import geotrellis.vector._
 import geotrellis.vector.Geometry
 import geotrellis.raster._
+import geotrellis.layer._
+
 import cats.data.{NonEmptyList => NEL, _}
 import Validated._
 

--- a/jvm/src/main/scala/eval/tile/TileLayouts.scala
+++ b/jvm/src/main/scala/eval/tile/TileLayouts.scala
@@ -3,7 +3,7 @@ package com.azavea.maml.eval.tile
 import com.typesafe.scalalogging.LazyLogging
 import geotrellis.proj4.WebMercator
 import geotrellis.raster._
-import geotrellis.spark.tiling._
+import geotrellis.layer._
 
 
 /** This interpreter handles resource resolution and compilation of MapAlgebra ASTs */

--- a/jvm/src/test/scala/eval/ResultSpec.scala
+++ b/jvm/src/test/scala/eval/ResultSpec.scala
@@ -59,7 +59,7 @@ class ResultSpec extends FunSpec with Matchers {
 
   it("Evaluate mask out data according to a mask") {
     val rasterOnes = LazyRaster(IntArrayTile(1 to 16 toArray, 4, 4), Extent(0, 0, 3, 3), WebMercator)
-    val mask = Extent(0, 0, 1, 1).as[Polygon].map(MultiPolygon(_)).get
+    val mask = MultiPolygon(Extent(0, 0, 1, 1).toPolygon)
     val maskResult = ImageResult(LazyMultibandRaster(List(MaskingNode(List(rasterOnes), mask))))
 
 

--- a/spark/src/main/scala/eval/RDDResult.scala
+++ b/spark/src/main/scala/eval/RDDResult.scala
@@ -9,6 +9,7 @@ import cats.data.{NonEmptyList => NEL, _}
 import cats.data.Validated._
 import geotrellis.raster._
 import geotrellis.spark._
+import geotrellis.layer._
 
 import scala.reflect.ClassTag
 

--- a/spark/src/main/scala/eval/directive/RDDOpDirectives.scala
+++ b/spark/src/main/scala/eval/directive/RDDOpDirectives.scala
@@ -11,12 +11,14 @@ import cats._
 import cats.data.{NonEmptyList => NEL, _}
 import cats.data.Validated._
 import cats.implicits._
+
+import geotrellis.layer._
 import geotrellis.raster._
-import geotrellis.raster.render._
 import geotrellis.raster.mapalgebra.{local => gt}
 import geotrellis.spark._
 import geotrellis.spark.render._
 import geotrellis.vector._
+
 import org.apache.spark.rdd._
 
 

--- a/spark/src/main/scala/eval/directive/RDDSourceDirectives.scala
+++ b/spark/src/main/scala/eval/directive/RDDSourceDirectives.scala
@@ -7,6 +7,7 @@ import com.azavea.maml.ast._
 import com.azavea.maml.spark.eval._
 
 import geotrellis.spark._
+import geotrellis.layer._
 import cats.data.{NonEmptyList => NEL, _}
 import cats.data.Validated._
 

--- a/spark/src/test/scala/RDDOpDirectivesSpec.scala
+++ b/spark/src/test/scala/RDDOpDirectivesSpec.scala
@@ -15,8 +15,10 @@ import cats._
 import cats.data.{NonEmptyList => NEL, _}
 import cats.data.Validated._
 import org.scalatest._
+
 import geotrellis.raster._
 import geotrellis.spark._
+import geotrellis.layer._
 import geotrellis.spark.testkit._
 
 import scala.reflect._


### PR DESCRIPTION
## Overview

This PR brings the primary dependency (GeoTrellis) up to date and facilitates upgrades of downstream libs such as GeoTrellis-Server

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible


### Notes

I had to propagate an annoying fix for jackson overrides so that Spark would run.

