### PR TITLE
Add focal aspect support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.6.0] - 2020-02-06
+### Added
+- Added support for Focal Aspect calculations [#103](https://github.com/geotrellis/maml/issues/103)
+
 ### Changed
  - GeoTrellis 3.2.0 and bump dependencies for scala 2.12 build [#112](https://github.com/geotrellis/maml/pull/112)
 

--- a/jvm/src/main/scala/eval/NaiveInterpreter.scala
+++ b/jvm/src/main/scala/eval/NaiveInterpreter.scala
@@ -89,7 +89,8 @@ object NaiveInterpreter {
       FocalDirectives.sum,
       FocalDirectives.standardDeviation,
       FocalDirectives.slope,
-      FocalDirectives.hillshade
+      FocalDirectives.hillshade,
+      FocalDirectives.aspect
     )
   )
 }

--- a/jvm/src/main/scala/eval/directive/FocalDirectives.scala
+++ b/jvm/src/main/scala/eval/directive/FocalDirectives.scala
@@ -10,6 +10,7 @@ import geotrellis.raster.Tile
 import geotrellis.raster.mapalgebra.focal
 import geotrellis.vector.Point
 import geotrellis.proj4.{CRS, LatLng}
+
 import cats._
 import cats.implicits._
 import cats.data.{NonEmptyList => NEL, _}
@@ -111,6 +112,17 @@ object FocalDirectives {
           1 / (EQUATOR_METERS * math.cos(math.toRadians(middleY)))
         }
         ImageResult(image.hillshade(None, zfactor, re.cellSize, azimuth, altitude))
+      })
+  }
+
+  val aspect = Directive { case (fm@FocalAspect(_), childResults) =>
+    childResults
+      .map({ _.as[LazyMultibandRaster] })
+      .toList.sequence
+      .map({ lr =>
+        val image = lr.head
+        val re = image.rasterExtent
+        ImageResult(image.aspect(None, re.cellSize))
       })
   }
 }

--- a/jvm/src/main/scala/eval/tile/LazyMultibandRaster.scala
+++ b/jvm/src/main/scala/eval/tile/LazyMultibandRaster.scala
@@ -88,6 +88,16 @@ case class LazyMultibandRaster(val bands: Map[String, LazyRaster]) {
     LazyMultibandRaster(lztiles)
   }
 
+  def aspect(
+    gridbounds: Option[GridBounds[Int]],
+    cs: CellSize
+  ): LazyMultibandRaster = {
+    val lztiles = bands.mapValues({ lt =>
+      LazyRaster.Aspect(List(lt), gridbounds, cs)
+    })
+    LazyMultibandRaster(lztiles)
+  }
+
   def mask(
     maskPoly: MultiPolygon
   ): LazyMultibandRaster = {

--- a/jvm/src/main/scala/eval/tile/LazyRaster.scala
+++ b/jvm/src/main/scala/eval/tile/LazyRaster.scala
@@ -4,7 +4,7 @@ import com.azavea.maml.eval._
 
 import geotrellis.raster._
 import geotrellis.raster.mapalgebra.local._
-import geotrellis.raster.mapalgebra.focal.{Square, Neighborhood, TargetCell, Slope => GTFocalSlope}
+import geotrellis.raster.mapalgebra.focal.{Square, Neighborhood, TargetCell, Slope => GTFocalSlope, Aspect => GTAspect}
 import geotrellis.raster.mapalgebra.focal.hillshade.{Hillshade => GTHillshade}
 import geotrellis.raster.render._
 import geotrellis.vector.{Extent, MultiPolygon, Point}
@@ -198,6 +198,23 @@ object LazyRaster {
       GTHillshade(fst.evaluate, Square(1), gridbounds, cs, azimuth, altitude, zFactor, TargetCell.All)
     lazy val dblTile =
       GTHillshade(fst.evaluateDouble, Square(1), gridbounds, cs, azimuth, altitude, zFactor, TargetCell.All)
+
+    def get(col: Int, row: Int) = intTile.get(col, row)
+    def getDouble(col: Int, row: Int) = dblTile.get(col, row)
+  }
+
+  case class Aspect(
+    children: List[LazyRaster],
+    gridbounds: Option[GridBounds[Int]],
+    cs: CellSize
+  ) extends UnaryBranch {
+    override lazy val cols: Int = gridbounds.map(_.width).getOrElse(fst.cols)
+    override lazy val rows: Int = gridbounds.map(_.height).getOrElse(fst.rows)
+
+    lazy val intTile =
+      GTAspect(fst.evaluate, Square(1), gridbounds, cs, TargetCell.All)
+    lazy val dblTile =
+      GTAspect(fst.evaluateDouble, Square(1), gridbounds, cs, TargetCell.All)
 
     def get(col: Int, row: Int) = intTile.get(col, row)
     def getDouble(col: Int, row: Int) = dblTile.get(col, row)

--- a/jvm/src/test/scala/eval/ConcurrentEvaluationSpec.scala
+++ b/jvm/src/test/scala/eval/ConcurrentEvaluationSpec.scala
@@ -312,6 +312,11 @@ class ConcurrentEvaluationSpec
       case Valid(t)       => t.bands.head.get(5, 5) should be(10)
       case i @ Invalid(_) => fail(s"$i")
     }
+    interpreter(FocalAspect(List(IntArrayTile(1 to 100 toArray, 10, 10)))).unsafeRunSync
+      .as[MultibandTile] match {
+      case Valid(t)       => t.bands.head.get(5, 5) should be(354)
+      case i @ Invalid(_) => fail(s"$i")
+    }
 
     /** The hillshade test is a bit more involved than some of the above
       *  See http://bit.ly/Qj0YPg for more information about the proper interpretation

--- a/jvm/src/test/scala/eval/EvaluationSpec.scala
+++ b/jvm/src/test/scala/eval/EvaluationSpec.scala
@@ -192,6 +192,10 @@ class EvaluationSpec extends FunSpec with Matchers with ExpressionTreeCodec {
       case Valid(t) => t.bands.head.get(5, 5) should be (10)
       case i@Invalid(_) => fail(s"$i")
     }
+    interpreter(FocalAspect(List(IntArrayTile(1 to 100 toArray, 10, 10)))).as[MultibandTile] match {
+      case Valid(t) => t.bands.head.get(5, 5) should be (354)
+      case i@Invalid(_) => fail(s"$i")
+    }
 
     /** The hillshade test is a bit more involved than some of the above
      *  See http://bit.ly/Qj0YPg for more information about the proper interpretation

--- a/shared/src/main/scala/ast/Expression.scala
+++ b/shared/src/main/scala/ast/Expression.scala
@@ -304,6 +304,12 @@ case class FocalHillshade(children: List[Expression], azimuth: Double, altitude:
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
+case class FocalAspect(children: List[Expression]) extends Expression("faspect") with FocalExpression {
+  // Not used in this focal operation
+  def neighborhood = Square(1)
+  def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
+}
+
 case class ImageSelect(children: List[Expression], labels: List[String]) extends Expression("sel") with UnaryExpression {
   val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.imageOnly
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)

--- a/shared/src/main/scala/ast/codec/MamlCodecInstances.scala
+++ b/shared/src/main/scala/ast/codec/MamlCodecInstances.scala
@@ -114,6 +114,13 @@ trait MamlCodecInstances extends MamlUtilityCodecs {
       (u.children, u.azimuth, u.altitude, u.sym)
     )
 
+  implicit lazy val decodeFocalAspect: Decoder[FocalAspect] =
+    Decoder.forProduct1("args")(FocalAspect.apply)
+  implicit lazy val encodeFocalAspect: Encoder[FocalAspect] =
+    Encoder.forProduct2("args", "symbol")(u =>
+      (u.children, u.sym)
+    )
+
   implicit lazy val decodeGreater: Decoder[Greater] =
     Decoder.forProduct1("args"){ args: List[Expression] => Greater(args) }
   implicit lazy val encodeGreater: Encoder[Greater] =

--- a/shared/src/main/scala/ast/codec/tree/ExpressionTreeCodec.scala
+++ b/shared/src/main/scala/ast/codec/tree/ExpressionTreeCodec.scala
@@ -43,6 +43,7 @@ trait ExpressionTreeCodec extends MamlCodecInstances {
     case fstddev @ FocalStdDev(_, _) => fstddev.asJson
     case fslope @ FocalSlope(_) => fslope.asJson
     case fhillshade @ FocalHillshade(_, _, _) => fhillshade.asJson
+    case faspect @ FocalAspect(_) => faspect.asJson
     case imgsel @ ImageSelect(_, _) => imgsel.asJson
     case lneg @ LogicalNegation(_) => lneg.asJson
     case nneg @ NumericNegation(_) => nneg.asJson
@@ -130,6 +131,7 @@ trait ExpressionTreeCodec extends MamlCodecInstances {
       case "fstddev" => Decoder[FocalStdDev]
       case "fslope" => Decoder[FocalSlope]
       case "fhillshade" => Decoder[FocalHillshade]
+      case "faspect" => Decoder[FocalAspect]
       case "sel" => Decoder[ImageSelect]
       case "int" => Decoder[IntLit]
       case "intV" => Decoder[IntVar]


### PR DESCRIPTION
## Overview

This PR adds support for focal aspect calculation to the MAML AST and interpreters

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

## Testing Instructions

Run `mamlJVM` tests

Closes #103
