### PR TITLE
Receive GPG key while publishing artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,10 +25,10 @@ aliases:
     - run:
         name: "Import signing key"
         command: |
+          gpg --keyserver keyserver.ubuntu.com \
+            --recv-keys 0x13E9AA1D8153E95E && \
           echo "${GPG_KEY}" | base64 -d > signing_key.asc && \
-          gpg --batch \
-            --passphrase "${GPG_PASSPHRASE}" \
-            --import signing_key.asc
+          gpg --import signing_key.asc
     - run:
         name: Executing cipublish
         command: ./scripts/cipublish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,6 @@ workflows:
                 - develop
                 - /release\/.*/
                 - /hotfix\/.*/
-                - feature/jrb/receive-gpg-key
 
 jobs:
   "openjdk8-scala2.11.12-nodelts":

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,7 @@ workflows:
                 - develop
                 - /release\/.*/
                 - /hotfix\/.*/
+                - feature/jrb/receive-gpg-key
 
 jobs:
   "openjdk8-scala2.11.12-nodelts":

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add TargetCell Parameter to Focal operations [#118](https://github.com/geotrellis/maml/pull/118)
 - Expose Focal Slope and Hillshade zFactor [#119](https://github.com/geotrellis/maml/pull/119)
 - RGB composite as MAML operation, Rescale and Normalize nodes [#114](https://github.com/geotrellis/maml/issues/114)
+- Receive GPG key while publishing artifacts [#122](https://github.com/geotrellis/maml/issues/122)
 
 ## [0.6.0] - 2020-02-06
 ### Added


### PR DESCRIPTION
## Overview

We've [added](http://keyserver.ubuntu.com/pks/lookup?search=0x52D6103D31A87CB6&fingerprint=on&op=index) a new signature to the GeoTrellis public key to extend the validity of the signing subkey. 

This change set receives the latest copy of the public key at the start of the `cipublish` build stage, allowing us to "renew" the key in the future without needing to update the key pair stored in CircleCI secrets.

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible
## Testing Instructions

See CircleCI build: https://app.circleci.com/pipelines/github/geotrellis/maml/194/workflows/653a1f28-9328-40e6-8f90-6f6e9e450868/jobs/539/steps

Connects https://github.com/azavea/operations/issues/446
