### PR TITLE
[WIP] Expose InterpretAs MAML node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Expose Convert and InterpretAs MAML nodes [#125](https://github.com/geotrellis/maml/pull/125)
 
 ## [0.6.1] - 2020-06-23
 ### Added

--- a/jvm/src/main/scala/eval/NaiveInterpreter.scala
+++ b/jvm/src/main/scala/eval/NaiveInterpreter.scala
@@ -95,7 +95,9 @@ object NaiveInterpreter {
       OpDirectives.assembleTile,
       UnaryDirectives.rescale,
       UnaryDirectives.normalize,
-      UnaryDirectives.clamp
+      UnaryDirectives.clamp,
+      UnaryDirectives.convert,
+      UnaryDirectives.interpretAs
     )
   )
 }

--- a/jvm/src/main/scala/eval/directive/UnaryDirectives.scala
+++ b/jvm/src/main/scala/eval/directive/UnaryDirectives.scala
@@ -5,16 +5,12 @@ import com.azavea.maml.eval._
 import com.azavea.maml.eval.tile._
 import com.azavea.maml.ast._
 import com.azavea.maml.dsl.tile._
-
 import cats._
 import cats.implicits._
 import cats.data.{NonEmptyList => NEL, _}
 import Validated._
 import geotrellis.raster._
 import geotrellis.raster.render._
-
-import scala.util.Try
-
 
 object UnaryDirectives {
 
@@ -180,6 +176,20 @@ object UnaryDirectives {
       case ImageResult(mbLzTile) =>
         Valid(ImageResult(band.fold(mbLzTile)(_ => mbLzTile.select(band.toList)).clamp(min, max)))
       case _ => Invalid(NEL.of(NonEvaluableNode(clamp, Some("Clamp node requires multiband lazyraster argument"))))
+    }
+  }
+
+  val convert = Directive { case (convert @ Convert(_, cellType), childResults) =>
+    childResults.head match {
+      case ImageResult(lzTile) => Valid(ImageResult(lzTile.convert(cellType)))
+      case _ => Invalid(NEL.of(NonEvaluableNode(convert, Some("Convert node requires multiband lazyraster argument"))))
+    }
+  }
+
+  val interpretAs = Directive { case (interepretAs @ InterpretAs(_, cellType), childResults) =>
+    childResults.head match {
+      case ImageResult(lzTile) => Valid(ImageResult(lzTile.interpretAs(cellType)))
+      case _ => Invalid(NEL.of(NonEvaluableNode(interepretAs, Some("InterepretAs node requires multiband lazyraster argument"))))
     }
   }
 }

--- a/jvm/src/main/scala/eval/tile/LazyMultibandRaster.scala
+++ b/jvm/src/main/scala/eval/tile/LazyMultibandRaster.scala
@@ -110,6 +110,16 @@ case class LazyMultibandRaster(bands: Map[String, LazyRaster]) {
     val lztiles = bands.mapValues({ lt => LazyRaster.Clamp(List(lt), min, max) })
     LazyMultibandRaster(lztiles)
   }
+
+  def convert(cellType: CellType): LazyMultibandRaster = {
+    val lztiles = bands.mapValues({ lt => LazyRaster.Convert(List(lt), cellType) })
+    LazyMultibandRaster(lztiles)
+  }
+
+  def interpretAs(cellType: CellType): LazyMultibandRaster = {
+    val lztiles = bands.mapValues({ lt => LazyRaster.InterpretAs(List(lt), cellType) })
+    LazyMultibandRaster(lztiles)
+  }
 }
 
 object LazyMultibandRaster {

--- a/jvm/src/main/scala/eval/tile/LazyRaster.scala
+++ b/jvm/src/main/scala/eval/tile/LazyRaster.scala
@@ -1,6 +1,5 @@
 package com.azavea.maml.eval.tile
 
-import cats.Semigroup
 import geotrellis.raster._
 import geotrellis.raster.mapalgebra.focal.{Neighborhood, Square, TargetCell, Aspect => GTAspect, Slope => GTFocalSlope}
 import geotrellis.raster.mapalgebra.focal.hillshade.{Hillshade => GTHillshade}
@@ -140,6 +139,28 @@ object LazyRaster {
   case class RasterCombineDouble(children: List[LazyRaster], scalar: Double, f: (Double, Double) => Double) extends UnaryBranch {
     def get(col: Int, row: Int) = d2i(getDouble(col, row))
     def getDouble(col: Int, row: Int) = f(fst.getDouble(col, row), scalar)
+  }
+
+  case class Convert(
+    children: List[LazyRaster],
+    cellType: CellType
+  ) extends UnaryBranch {
+    lazy val intTile = fst.evaluate.convert(cellType)
+    lazy val dblTile = fst.evaluateDouble.convert(cellType)
+
+    def get(col: Int, row: Int) = intTile.get(col, row)
+    def getDouble(col: Int, row: Int) = dblTile.getDouble(col, row)
+  }
+
+  case class InterpretAs(
+    children: List[LazyRaster],
+    cellType: CellType
+  ) extends UnaryBranch {
+    lazy val intTile = fst.evaluate.interpretAs(cellType)
+    lazy val dblTile = fst.evaluateDouble.interpretAs(cellType)
+
+    def get(col: Int, row: Int) = intTile.get(col, row)
+    def getDouble(col: Int, row: Int) = dblTile.getDouble(col, row)
   }
 
   case class Rescale(

--- a/jvm/src/test/scala/eval/ConcurrentEvaluationSpec.scala
+++ b/jvm/src/test/scala/eval/ConcurrentEvaluationSpec.scala
@@ -418,6 +418,26 @@ class ConcurrentEvaluationSpec
       case i @ Invalid(_) => fail(s"$i")
     }
 
+    interpreter(
+      Convert(DoubleArrayTile((1 to 100).map(_ + 0.1) toArray, 10, 10) :: Nil, IntUserDefinedNoDataCellType(1))
+    ).unsafeRunSync.as[MultibandTile] match {
+      case Valid(t) =>
+        val b = t.band(0)
+        b.get(0, 0) should be(NODATA)
+        val arr = b.toArrayDouble
+        (2 to 100).zipWithIndex.foreach { case (v, idx) => arr(idx + 1) shouldBe v.toDouble }
+
+      case i @ Invalid(_) => fail(s"$i")
+    }
+
+    interpreter(
+      InterpretAs(IntArrayTile(1 to 100 toArray, 10, 10) :: Nil, IntUserDefinedNoDataCellType(1))
+    ).unsafeRunSync.as[MultibandTile] match {
+      case Valid(t) =>
+        t.band(0).get(0, 0) should be(NODATA)
+      case i @ Invalid(_) => fail(s"$i")
+    }
+
     /** The hillshade test is a bit more involved than some of the above
       *  See http://bit.ly/Qj0YPg for more information about the proper interpretation
       *   of hillshade values

--- a/shared/src/main/scala/ast/Expression.scala
+++ b/shared/src/main/scala/ast/Expression.scala
@@ -292,6 +292,16 @@ case class Clamp(children: List[Expression], min: Double, max: Double, band: Opt
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }
 
+case class Convert(children: List[Expression], cellType: CellType) extends Expression("convert") with UnaryExpression {
+  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.imageOrScalar
+  def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
+}
+
+case class InterpretAs(children: List[Expression], cellType: CellType) extends Expression("interpretAs") with UnaryExpression {
+  val kindDerivation: Map[MamlKind, MamlKind] = UnaryExpression.imageOrScalar
+  def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
+}
+
 case class FocalMax(children: List[Expression], neighborhood: Neighborhood, target: TargetCell = TargetCell.All) extends Expression("fmax") with FocalExpression {
   def withChildren(newChildren: List[Expression]): Expression = copy(children = newChildren)
 }

--- a/shared/src/main/scala/ast/codec/MamlCodecInstances.scala
+++ b/shared/src/main/scala/ast/codec/MamlCodecInstances.scala
@@ -369,4 +369,14 @@ trait MamlCodecInstances extends MamlUtilityCodecs {
     Decoder.forProduct4("args", "min", "max", "band")(Clamp.apply)
   implicit lazy val encodeClamp: Encoder[Clamp] =
     Encoder.forProduct5("args", "min", "max", "band", "symbol")(u => (u.children, u.min, u.max, u.band, u.sym))
+
+  implicit lazy val decodeConvert: Decoder[Convert] =
+    Decoder.forProduct2("args", "cellType")(Convert.apply)
+  implicit lazy val encodeConvert: Encoder[Convert] =
+    Encoder.forProduct3("args", "cellType", "symbol")(u => (u.children, u.cellType, u.sym))
+
+  implicit lazy val decodeInterpretAs: Decoder[InterpretAs] =
+    Decoder.forProduct2("args", "cellType")(InterpretAs.apply)
+  implicit lazy val encodeInterpretAs: Encoder[InterpretAs] =
+    Encoder.forProduct3("args", "cellType", "symbol")(u => (u.children, u.cellType, u.sym))
 }

--- a/shared/src/main/scala/ast/codec/tree/ExpressionTreeCodec.scala
+++ b/shared/src/main/scala/ast/codec/tree/ExpressionTreeCodec.scala
@@ -79,6 +79,8 @@ trait ExpressionTreeCodec extends MamlCodecInstances {
     case rescale @ Rescale(_, _, _, _) => rescale.asJson
     case normalize @ Normalize(_, _, _, _, _, _) => normalize.asJson
     case clamp @ Clamp(_, _, _, _) => clamp.asJson
+    case convert @ Convert(_, _) => convert.asJson
+    case interpretAs @ InterpretAs(_, _) => interpretAs.asJson
   }
 
   implicit lazy val totalDecoder: Decoder[Expression] = Decoder.instance[Expression] { cursor =>
@@ -149,6 +151,8 @@ trait ExpressionTreeCodec extends MamlCodecInstances {
       case "rescale" => Decoder[Rescale]
       case "normalize" => Decoder[Normalize]
       case "clamp" => Decoder[Clamp]
+      case "convert" => Decoder[Convert]
+      case "interpretAs" => Decoder[InterpretAs]
     } match {
       case Some(decoder) => decoder.widen(cursor)
       case None =>  Left(DecodingFailure(s"No symbol provided for MAML expression", cursor.history))

--- a/shared/src/test/scala/ast/kind/KindSpec.scala
+++ b/shared/src/test/scala/ast/kind/KindSpec.scala
@@ -2,6 +2,7 @@ package com.azavea.maml.ast.kind
 
 import com.azavea.maml.ast._
 import com.azavea.maml.util._
+import geotrellis.raster.DoubleCellType
 
 import org.scalatest._
 
@@ -36,5 +37,13 @@ class KindSpec extends FunSpec with Matchers {
 
   it("Should correctly determine Assemble output type for a foldable operation") {
     Assemble(List(RasterVar("test1"), RasterVar("test2"), RasterVar("test3"))).kind should be (MamlKind.Image)
+  }
+
+  it("Should correctly determine Convert output type for a foldable operation (scalar)") {
+    Convert(RasterVar("test1") :: Nil, DoubleCellType).kind should be (MamlKind.Image)
+  }
+
+  it("Should correctly determine InterpretAs output type for a foldable operation (scalar)") {
+    InterpretAs(RasterVar("test1") :: Nil, DoubleCellType).kind should be (MamlKind.Image)
   }
 }


### PR DESCRIPTION
## Overview

This PR adds MAML nodes to add some control overt the tiles data types for intermediate operations and over the nodata values.

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

